### PR TITLE
add Only Build Backend #44

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,5 +78,14 @@ task<NpmTask>("buildReact") {
 }
 val processResources by tasks.existing(ProcessResources::class)
 processResources {
-    dependsOn("buildReact")
+    var buildFront = true
+    if (project.hasProperty("args")) {
+        val args = project.properties["args"] as? String
+        if (args?.split("""\s+""".toRegex())?.find{ it == "--only-back-end"} != null){
+            buildFront = false
+        }
+    }
+    if (buildFront) {
+        dependsOn("buildReact")
+    }
 }


### PR DESCRIPTION
バックエンドのみ起動するオプションを追加しました。
起動時はGradlewから
```
./gradlew bootRun -Pargs="--only-back-end"
```
とすることで、バックエンドのみ実行可能です。
publicディレクトリは削除していないですが、オプションを付けた時点で削除した方が嬉しいですかね？