### PR TITLE
chore(frontend): fix package.json to use npm instead of yarn

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,7 @@
     "eject": "react-scripts eject",
     "format": "sort-package-json && prettier --write \"**/{.*/,}*.{css,html,js,json,jsx,md,scss,ts,tsx,yaml,yml}\"",
     "lint": "eslint \"{src,__tests__}/**/*.{js,jsx,ts,tsx}\"",
-    "lint-fix": "yarn lint --fix",
+    "lint-fix": "npm run lint --fix",
     "start": "react-scripts start",
     "test": "react-scripts test",
     "typecheck": "tsc --noEmit"
@@ -16,7 +16,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "yarn typecheck"
+      "pre-push": "npm run typecheck"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
`npm`を使用しているパッケージなのに、癖で`yarn`を使用するように設定を記述していたので、修正しました。