### PR TITLE
fix(frontend): use appropriate components for header links

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Nav, Navbar } from 'react-bootstrap';
+import { Button, Nav, Navbar } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import { getCookieArray } from '../functions/GetCookieArray';
 
@@ -10,29 +10,29 @@ export const Header: React.FC = () => {
   if (cookieArray['_sforce_account_name']) {
     const name = cookieArray['_sforce_account_name'];
     rightHeader = (
-      <div>
-        <Nav.Link href={`/account/${name}`}>
-          <Navbar.Brand>{name}</Navbar.Brand>
+      <Nav>
+        <Nav.Link as={Link} to={`/account/${name}`}>
+          {name}
         </Nav.Link>
-      </div>
+      </Nav>
     );
   } else {
     rightHeader = (
-      <div>
-        <Link to={'/signup'}>
-          <Navbar.Brand>SignUp</Navbar.Brand>
-        </Link>
-        <Link to={'/login'}>
-          <Navbar.Brand>Login</Navbar.Brand>
-        </Link>
-      </div>
+      <Nav>
+        <Nav.Link as={Link} to={'/login'} className="mr-sm-2">
+          Login
+        </Nav.Link>
+        <Button as={Link} to={'/signup'} variant="outline-light">
+          Sign up
+        </Button>
+      </Nav>
     );
   }
 
   return (
     <Navbar bg="dark" variant="dark">
       <Nav className="mr-auto">
-        <Nav.Link href="/">
+        <Nav.Link as={Link} to="/">
           <Navbar.Brand>Shitforces</Navbar.Brand>
         </Nav.Link>
       </Nav>


### PR DESCRIPTION
close #107 

- `Header`でリンクに使用されているコンポーネントを適切なものに修正した。
- サインアップとログインのリンクの見た目をGitHubあたりを参考にして変更した。
  - ![image](https://user-images.githubusercontent.com/9990535/111753178-e66b3b00-88d9-11eb-861e-ea9bbe50c6c0.png)


Before
![image](https://user-images.githubusercontent.com/9990535/111752867-8b394880-88d9-11eb-9eba-88982cfcdf2d.png)

After
![image](https://user-images.githubusercontent.com/9990535/111752797-7bb9ff80-88d9-11eb-99dd-b1f3c37621bd.png)
