### PR TITLE
feat(frontend): centering the contents

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -36,3 +36,7 @@
     transform: rotate(360deg);
   }
 }
+
+.App-container {
+  background-color: #ffffff;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Container } from 'react-bootstrap';
 import { BrowserRouter as Router, Route, Switch } from 'react-router-dom';
 import { Header } from './components/Header';
 import { AccountPage } from './pages/AccountPage';
@@ -12,8 +13,8 @@ import './App.css';
 export const App: React.FC = () => {
   return (
     <Router>
-      <div>
-        <Header />
+      <Header />
+      <Container className="App-container p-3">
         <Switch>
           <Route exact key="/" path="/" component={MainPage} />
           <Route exact key="/login" path="/login" component={LoginPage} />
@@ -32,7 +33,7 @@ export const App: React.FC = () => {
           />
           <Route component={NotFoundPage} />
         </Switch>
-      </div>
+      </Container>
     </Router>
   );
 };

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,5 @@
 body {
+  background-color: #f5f5f5;
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -104,7 +104,7 @@ const RankingTable: React.FC<RankingTableProps> = ({
   };
 
   return (
-    <Table striped bordered hover>
+    <Table striped bordered hover responsive>
       <thead>
         <tr>
           <th>順位</th>


### PR DESCRIPTION
close #26 

ページの本文を中央寄せにする。

| Before | After |
|-|-|
| <img src="https://user-images.githubusercontent.com/9990535/112321192-19a33500-8cf3-11eb-9ddb-a933e64dfd7f.png" width="400"> | <img src="https://user-images.githubusercontent.com/9990535/112321132-08f2bf00-8cf3-11eb-9853-1e71a2102cba.png" width="400"> |


