### PR TITLE
feat(frontend): search on standings

### DIFF
--- a/frontend/src/components/RankingTable.tsx
+++ b/frontend/src/components/RankingTable.tsx
@@ -143,11 +143,12 @@ export const RankingTable: React.FC<Props> = ({
   const pagenatedAccounts = useMemo(
     () =>
       filteredAccounts.filter(
-        (_, i) =>
-          paginationIndex * ACCOUNTS_PER_PAGE <= i &&
-          i < (paginationIndex + 1) * ACCOUNTS_PER_PAGE
+        (v, i) =>
+          (paginationIndex * ACCOUNTS_PER_PAGE <= i &&
+            i < (paginationIndex + 1) * ACCOUNTS_PER_PAGE) ||
+          v.accountName === myAccountName
       ),
-    [filteredAccounts, paginationIndex]
+    [myAccountName, filteredAccounts, paginationIndex]
   );
 
   const paginationItems = useMemo(() => {

--- a/frontend/src/components/RankingTable.tsx
+++ b/frontend/src/components/RankingTable.tsx
@@ -1,7 +1,9 @@
-import React, { useMemo } from 'react';
-import { Alert, Table } from 'react-bootstrap';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, Button, Form, Pagination, Table } from 'react-bootstrap';
 import { toProblemLabel } from '../functions/toProblemLabel';
 import { ProblemInfo, RankingInfo, RankingInfoAccount } from '../types';
+
+const ACCOUNTS_PER_PAGE = 20;
 
 function formatSecondToMMSS(ms: number): string {
   const mm = Math.floor(ms / 60);
@@ -83,14 +85,83 @@ export const RankingTable: React.FC<Props> = ({
   problems,
   ranking,
 }) => {
-  if (problems.length !== ranking.acPerSubmit.length) {
-    return <Alert variant="danger">Error</Alert>;
-  }
+  const [accountNameToSearch, setAccountNameToSearch] = useState('');
+
+  const onChangeAccountName = useCallback<
+    React.ChangeEventHandler<HTMLInputElement>
+  >((event) => {
+    setAccountNameToSearch(event.target.value);
+  }, []);
+
+  const onClickReset = useCallback(() => {
+    setAccountNameToSearch('');
+  }, []);
 
   const sortedProblems = useMemo(
     () => problems.sort((a, b) => a.indexOfContest - b.indexOfContest),
     [problems]
   );
+
+  const filteredAccounts = useMemo(() => {
+    const uniqueAccounts = new Map<string, RankingInfoAccount>();
+    for (const account of ranking.rankingList) {
+      uniqueAccounts.set(account.accountName, account);
+    }
+
+    let accounts = Array.from(uniqueAccounts.values());
+
+    accounts = accounts.filter((v) =>
+      v.accountName.startsWith(accountNameToSearch)
+    );
+
+    return accounts;
+  }, [ranking.rankingList, accountNameToSearch]);
+
+  const paginationLength = useMemo(
+    () => Math.ceil(filteredAccounts.length / ACCOUNTS_PER_PAGE),
+    [filteredAccounts.length]
+  );
+
+  const [paginationIndex, setPaginationIndex] = useState(0);
+
+  useEffect(() => {
+    if (paginationLength === 0) {
+      if (paginationIndex !== 0) setPaginationIndex(0);
+      return;
+    }
+
+    if (paginationLength <= paginationIndex) {
+      setPaginationIndex(paginationLength - 1);
+    }
+  }, [paginationIndex, paginationLength]);
+
+  const pagenatedAccounts = useMemo(
+    () =>
+      filteredAccounts.filter(
+        (_, i) =>
+          paginationIndex * ACCOUNTS_PER_PAGE <= i &&
+          i < (paginationIndex + 1) * ACCOUNTS_PER_PAGE
+      ),
+    [filteredAccounts, paginationIndex]
+  );
+
+  const paginationItems = useMemo(() => {
+    const items = [];
+    for (let i = 0; i < Math.max(1, paginationLength); i++) {
+      items.push(
+        <Pagination.Item
+          key={i}
+          active={i === paginationIndex}
+          onClick={() => {
+            setPaginationIndex(i);
+          }}
+        >
+          {i + 1}
+        </Pagination.Item>
+      );
+    }
+    return items;
+  }, [paginationIndex, paginationLength]);
 
   const acPerSubmitRow = useMemo(
     () => (
@@ -110,32 +181,61 @@ export const RankingTable: React.FC<Props> = ({
     [ranking.acPerSubmit]
   );
 
+  if (problems.length !== ranking.acPerSubmit.length) {
+    return <Alert variant="danger">Error</Alert>;
+  }
+
   return (
-    <Table size="sm" striped bordered hover responsive>
-      <thead>
-        <tr className="text-center text-nowrap">
-          <th style={{ minWidth: '3em' }}>順位</th>
-          <th style={{ minWidth: '10em' }}>ユーザ</th>
-          <th style={{ minWidth: '4em' }}>得点</th>
-          {sortedProblems.map((problem) => (
-            <th key={problem.id} style={{ minWidth: '4em' }}>
-              {toProblemLabel(problem.indexOfContest)}
-            </th>
-          ))}
-        </tr>
-        {acPerSubmitRow}
-      </thead>
-      <tbody>
-        {ranking.rankingList.map((account, i) => (
-          <RankingTableRow
-            key={i}
-            account={account}
-            problems={sortedProblems}
-            isMe={account.accountName === myAccountName}
+    <>
+      <div className="mb-4">
+        <Form inline>
+          <Form.Label className="mr-2" htmlFor="ranking-table-form-username">
+            ユーザ名
+          </Form.Label>
+          <Form.Control
+            className="mr-2"
+            id="ranking-table-form-username"
+            onChange={onChangeAccountName}
+            value={accountNameToSearch}
           />
-        ))}
-      </tbody>
-      <tfoot>{acPerSubmitRow}</tfoot>
-    </Table>
+          <Button onClick={onClickReset} variant="secondary">
+            リセット
+          </Button>
+        </Form>
+      </div>
+
+      <Table size="sm" striped bordered hover responsive>
+        <thead>
+          <tr className="text-center text-nowrap">
+            <th style={{ minWidth: '3em' }}>順位</th>
+            <th style={{ minWidth: '10em' }}>ユーザ</th>
+            <th style={{ minWidth: '4em' }}>得点</th>
+            {sortedProblems.map((problem) => (
+              <th key={problem.id} style={{ minWidth: '4em' }}>
+                {toProblemLabel(problem.indexOfContest)}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {acPerSubmitRow}
+          {pagenatedAccounts.map((account, i) => (
+            <RankingTableRow
+              key={i}
+              account={account}
+              problems={sortedProblems}
+              isMe={account.accountName === myAccountName}
+            />
+          ))}
+        </tbody>
+        <tfoot>{acPerSubmitRow}</tfoot>
+      </Table>
+
+      <div className="mb-4">
+        <Pagination className="justify-content-center">
+          {paginationItems}
+        </Pagination>
+      </div>
+    </>
   );
 };

--- a/frontend/src/components/RankingTable.tsx
+++ b/frontend/src/components/RankingTable.tsx
@@ -114,6 +114,11 @@ export const RankingTable: React.FC<Props> = ({
       v.accountName.startsWith(accountNameToSearch)
     );
 
+    accounts = accounts.sort((a, b) => {
+      if (a.ranking !== b.ranking) return a.ranking - b.ranking;
+      return a.penalty - b.penalty;
+    });
+
     return accounts;
   }, [ranking.rankingList, accountNameToSearch]);
 

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -120,33 +120,28 @@ const RankingElement: React.FC<RankingElementProps> = ({
   const [ranking, setRanking] = useState<RankingInfo | null>(null);
   const [nowRankingVersion, setNowRankingVersion] = useState(0);
 
-  const ACCOUNTS_IN_ONE_PAGE = 20;
-
-  const getRanking = (newPage: any) => {
-    getRankingInfo(newPage, getContestId()).then((rankingInfo) => {
+  const getRanking = () => {
+    getRankingInfo(null, getContestId()).then((rankingInfo) => {
       setRanking(rankingInfo);
     });
   };
 
   if (nowRankingVersion !== rankingVersion) {
     setNowRankingVersion(rankingVersion);
-    getRanking(0);
+    getRanking();
   }
 
   useEffect(() => {
-    getRanking(0);
+    getRanking();
   }, []);
 
-  const pageNum = Math.ceil(
-    (ranking?.partAccountNum ?? 0) / ACCOUNTS_IN_ONE_PAGE
-  );
   let myRank = '';
   if (ranking?.requestAccountRank) {
     myRank = `順位: ${ranking.requestAccountRank}`;
   }
 
   return (
-    <div>
+    <>
       <p>{myRank}</p>
       {ranking && (
         <RankingTable
@@ -155,12 +150,10 @@ const RankingElement: React.FC<RankingElementProps> = ({
           ranking={ranking}
         />
       )}
-      <PagingElement
-        pageNum={pageNum}
-        pageChanged={getRanking}
-        reloadButton={true}
-      />
-    </div>
+      <Button onClick={getRanking} variant="secondary">
+        更新
+      </Button>
+    </>
   );
 };
 

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -321,6 +321,7 @@ const ProblemsTab: React.FC<ProblemsTabProps> = ({ problems, submissions }) => {
       </Tabs>
       {getElement()}
       <p>{comment}</p>
+      <hr />
       <RankingElement problems={problems} rankingVersion={rankingVersion} />
     </div>
   );


### PR DESCRIPTION
#156 

issueでは「検索・並べ替え」と言っていたけれど並べ替えは怠かった、もとい、PRが大きくなりそうだったので、検索機能だけでPRにしました。

`PagingElement`がpropsに`value`的なものを受け取らない所以で、`PagingElement`とコードを共通化できていませんが、追々直せればと考えています。（直そうとすると他の画面にも影響するので今は触らないでおきました。）