### PR TITLE
コンテストのPATCHの追加 #131

### DIFF
--- a/frontend/src/functions/HttpRequest.ts
+++ b/frontend/src/functions/HttpRequest.ts
@@ -254,6 +254,31 @@ export function putContestInfo(
 }
 
 /**
+ *
+ * @param contestId
+ * @param penalty
+ * @param statement
+ * @param problems
+ */
+export function patchContestInfo(
+  contestId: string,
+  penalty: number,
+  statement: string,
+  problems: { statement: string; point: number; answer: string[] }[]
+): Promise<void> {
+  const param = {
+    penalty: penalty,
+    statement: statement,
+    problems: problems,
+  };
+  return httpRequest(
+    `/api/contests/${contestId}`,
+    'PATCH',
+    JSON.stringify(param)
+  ) as Promise<void>;
+}
+
+/**
  * @param id
  */
 export function getProblemAnswer(id: number): Promise<string[]> {

--- a/src/main/kotlin/com/nazonazo_app/shit_forces/contest/ContestController.kt
+++ b/src/main/kotlin/com/nazonazo_app/shit_forces/contest/ContestController.kt
@@ -117,6 +117,15 @@ class ContestController(val contestService: ContestService,
     ) {
         contestService.putContestInfo(contestId, putRequestContest, httpServletRequest)
     }
+
+    @PatchMapping("api/contests/{contest_id}")
+    fun patchContestInfoResponse(@PathVariable("contest_id") contestId: String,
+                               @RequestBody putRequestContest: PutRequestContest,
+                               httpServletRequest: HttpServletRequest
+    ) {
+        contestService.patchContestInfo(contestId, putRequestContest, httpServletRequest)
+    }
+
     @GetMapping("api/problems/{problem_id}/answer")
     fun getAnswerByIdResponse(@PathVariable("problem_id") id: Int,
                               httpServletRequest: HttpServletRequest

--- a/src/main/kotlin/com/nazonazo_app/shit_forces/contest/ContestRepository.kt
+++ b/src/main/kotlin/com/nazonazo_app/shit_forces/contest/ContestRepository.kt
@@ -88,4 +88,5 @@ class ContestRepository(val jdbcTemplate: JdbcTemplate) {
         """, putContest.statement, putContest.penalty, contestId
         )
     }
+
 }

--- a/src/main/kotlin/com/nazonazo_app/shit_forces/contest/ContestService.kt
+++ b/src/main/kotlin/com/nazonazo_app/shit_forces/contest/ContestService.kt
@@ -286,6 +286,52 @@ class ContestService(private val contestRepository: ContestRepository,
                        putRequestContest: PutRequestContest,
                        httpServletRequest: HttpServletRequest
     ) {
+        val contestInfo = validateContestUpdatable(contestId, httpServletRequest)
+        val now = Timestamp(System.currentTimeMillis())
+        val validSubmission = sharedSubmissionService.getContestSubmissionInTime(contestInfo)
+        if (now >= contestInfo.startTime && validSubmission.isNotEmpty()) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN)
+        }
+        val problems = putRequestContest.problems.mapIndexed { index, it ->
+            ProblemInfo(contestId, it.point, it.statement, index, it.answer)
+        }
+        contestRepository.updateContestInfoByPutRequestContest(contestId, putRequestContest)
+        sharedProblemService.updateContestProblem(contestInfo.id, problems)
+    }
+
+    fun patchContestInfo(contestId: String,
+                       putRequestContest: PutRequestContest,
+                       httpServletRequest: HttpServletRequest
+    ) {
+        val contestInfo = validateContestUpdatable(contestId, httpServletRequest)
+        val validSubmission = sharedSubmissionService.getContestSubmissionInTime(contestInfo)
+        if (validSubmission.isEmpty()) {
+            // 過去問編集用の処理なので、putContestを行う
+            putContestInfo(contestId, putRequestContest, httpServletRequest)
+            return
+        }
+        val nowContestProblem = sharedProblemService.getProblemsByContestId(contestId)
+        val newProblems = putRequestContest.problems.mapIndexed { index, it ->
+            ProblemInfo(contestId, it.point, it.statement, index, it.answer)
+        }
+        if (nowContestProblem.size != newProblems.size) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST)
+        }
+        val problemNum = nowContestProblem.size
+        for (i in 0 until problemNum) {
+            if (nowContestProblem[i].answer != newProblems[i].answer ||
+                    nowContestProblem[i].point != newProblems[i].point) {
+                throw ResponseStatusException(HttpStatus.BAD_REQUEST)
+            }
+        }
+        contestRepository.updateContestInfoByPutRequestContest(contestId, putRequestContest)
+        sharedProblemService.updateContestProblemStatement(contestId, newProblems)
+    }
+
+    private fun validateContestUpdatable(
+        contestId: String,
+        httpServletRequest: HttpServletRequest
+    ): ContestInfo {
         val contestInfo = getContestInfoByContestId(contestId)
             ?: throw ResponseStatusException(HttpStatus.NOT_FOUND)
         val accountName = sharedSessionService.getSessionAccountName(httpServletRequest)
@@ -293,15 +339,7 @@ class ContestService(private val contestRepository: ContestRepository,
         if (contestInfo.contestCreators.find { it.accountName == accountName } == null) {
             throw ResponseStatusException(HttpStatus.FORBIDDEN)
         }
-        val problems = putRequestContest.problems.mapIndexed { index, it ->
-            ProblemInfo(contestId, it.point, it.statement, index, it.answer)
-        }
-        contestRepository.updateContestInfoByPutRequestContest(contestId, putRequestContest)
-        val now = Timestamp(System.currentTimeMillis())
-        val validSubmission = sharedSubmissionService.getContestSubmissionInTime(contestInfo)
-        if (now < contestInfo.startTime || validSubmission.isEmpty()) {
-            sharedProblemService.updateContestProblem(contestInfo.id, problems)
-        }
+        return contestInfo
     }
 
     fun getProblemAnswer(id: Int, httpServletRequest: HttpServletRequest): List<String> {

--- a/src/main/kotlin/com/nazonazo_app/shit_forces/contest/ContestService.kt
+++ b/src/main/kotlin/com/nazonazo_app/shit_forces/contest/ContestService.kt
@@ -317,6 +317,9 @@ class ContestService(private val contestRepository: ContestRepository,
         if (nowContestProblem.size != newProblems.size) {
             throw ResponseStatusException(HttpStatus.BAD_REQUEST)
         }
+        if (contestInfo.penalty != putRequestContest.penalty) {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST)
+        }
         val problemNum = nowContestProblem.size
         for (i in 0 until problemNum) {
             if (nowContestProblem[i].answer != newProblems[i].answer ||

--- a/src/main/kotlin/com/nazonazo_app/shit_forces/problem/ProblemRepository.kt
+++ b/src/main/kotlin/com/nazonazo_app/shit_forces/problem/ProblemRepository.kt
@@ -62,6 +62,14 @@ class ProblemRepository(private val jdbcTemplate: JdbcTemplate) {
             }
         }
     }
+    fun updateProblemStatement(contestId: String, problems: List<ProblemInfo>) {
+        problems.forEach {
+            jdbcTemplate.update("""
+                UPDATE problemInfo set statement = ? 
+                WHERE contestId = ? and indexOfContest = ?
+            """, it.statement, contestId, it.indexOfContest)
+        }
+    }
     fun findById(id: Int) : ProblemInfo? {
         val problem = jdbcTemplate.query("""
                 SELECT id, contestId, contestId, point, statement, indexOfContest FROM problemInfo 

--- a/src/main/kotlin/com/nazonazo_app/shit_forces/problem/SharedProblemService.kt
+++ b/src/main/kotlin/com/nazonazo_app/shit_forces/problem/SharedProblemService.kt
@@ -13,12 +13,14 @@ class SharedProblemService(private val problemRepository: ProblemRepository) {
             listOf()
         }
     }
+
     fun getContestProblemScores(contestName: String): List<Int?> =
         try{
             problemRepository.findByContestId(contestName).map{it.point}
         } catch (e: Error) {
             listOf()
         }
+
     fun getContestProblemByNameAndIndex(contestName: String, indexOfContest: Int): ProblemInfo? =
         try {
             problemRepository.findByContestIdAndIndex(contestName, indexOfContest)
@@ -26,6 +28,7 @@ class SharedProblemService(private val problemRepository: ProblemRepository) {
             print(e)
             null
         }
+
     fun updateContestProblem(contestId: String, newProblems: List<ProblemInfo>) {
         val prevProblem = problemRepository.findByContestId(contestId)
         prevProblem.forEach {
@@ -33,9 +36,15 @@ class SharedProblemService(private val problemRepository: ProblemRepository) {
         }
         problemRepository.addProblems(contestId, newProblems)
     }
+
+    fun updateContestProblemStatement(contestId: String, newProblems: List<ProblemInfo>) {
+        problemRepository.updateProblemStatement(contestId, newProblems)
+    }
+
     fun getProblemById(id: Int): ProblemInfo? {
         return problemRepository.findById(id)
     }
+
     fun getAnswersById(id: Int): List<String> {
         return problemRepository.findAnswersById(id)
     }


### PR DESCRIPTION
コンテスト開始後以降はPATCHのリクエストを送信する形にしました。
PATCHでは、リクエストの問題数が一致しているか、答えが同じか、点数が同じかをチェックします。<br>
更新されるのはコンテスト説明、ペナルティ、問題文のみです。

ただし過去問編集用に、valid submissionが無かった場合はPUT時と同様の処理をさせます。