### PR TITLE
give account name the color of rating close #153

### DIFF
--- a/frontend/src/functions/getRatingColor.ts
+++ b/frontend/src/functions/getRatingColor.ts
@@ -1,0 +1,25 @@
+export const getRatingColor = (rating: number): string => {
+  let rateColor = '';
+  if (rating === 0) {
+    rateColor = 'black';
+  } else if (rating < 400) {
+    rateColor = 'gray';
+  } else if (rating < 800) {
+    rateColor = 'brown';
+  } else if (rating < 1200) {
+    rateColor = 'green';
+  } else if (rating < 1600) {
+    // cyan
+    rateColor = '#00C0C0';
+  } else if (rating < 2000) {
+    rateColor = 'blue';
+  } else if (rating < 2400) {
+    // yellow
+    rateColor = '#C0C000';
+  } else if (rating < 2800) {
+    rateColor = 'orange';
+  } else {
+    rateColor = 'red';
+  }
+  return rateColor;
+};

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -15,6 +15,7 @@ import Tabs from 'react-bootstrap/Tabs';
 import { useAuthentication } from '../contexts/AuthenticationContext';
 import { isValidAccountNameOrPassWord } from '../functions/AccountInfoSubmitValidation';
 import { getAccountInformation, createContest } from '../functions/HttpRequest';
+import { getRatingColor } from '../functions/getRatingColor';
 
 // URL: /account/$accountName
 
@@ -252,15 +253,19 @@ interface AccountInformationBodyProps {
   rating: number;
 }
 
-const AccountInformationBody: React.FC<AccountInformationBodyProps> = (
-  props
-) => {
+const AccountInformationBody: React.FC<AccountInformationBodyProps> = ({
+  name,
+  rating,
+}) => {
   const { accountName, signOut } = useAuthentication();
+  const ratingColor = getRatingColor(rating);
 
   return (
     <div>
-      <p>アカウント名: {props.name}</p>
-      <p>レート: {props.rating}</p>
+      <p>アカウント名: {name}</p>
+      <p>
+        レート: <span style={{ color: ratingColor }}>{rating}</span>
+      </p>
       {accountName !== null && (
         <Button variant="primary" onClick={signOut}>
           ログアウト
@@ -352,6 +357,7 @@ interface AccountInfoTabsProps {
 const AccountInfoTabs: React.FC<AccountInfoTabsProps> = (props) => {
   const [key, setKey] = useState<string | null>('profile');
   const tabs = [];
+
   tabs.push(
     <Tab eventKey={'profile'} title={'プロフィール'}>
       <AccountInformationBody name={props.name} rating={props.rating} />

--- a/frontend/src/pages/RankingPage.tsx
+++ b/frontend/src/pages/RankingPage.tsx
@@ -3,6 +3,7 @@ import Table from 'react-bootstrap/Table';
 import { Link } from 'react-router-dom';
 import { PagingElement } from '../components/PagingElement';
 import { getAccountRankingInfo } from '../functions/HttpRequest';
+import { getRatingColor } from '../functions/getRatingColor';
 import { AccountInfo } from '../types';
 
 const ACCOUNT_RANKING_ONE_PAGE = 20;
@@ -16,28 +17,8 @@ export const AccountRankingTable: React.FC<AccountRankingTableProps> = ({
 }) => {
   const tableBody = (() => {
     const cols = accounts.map((account, idx) => {
-      let ratingColor;
-      if (account.rating === 0) {
-        ratingColor = 'black';
-      } else if (account.rating < 400) {
-        ratingColor = 'gray';
-      } else if (account.rating < 800) {
-        ratingColor = 'brown';
-      } else if (account.rating < 1200) {
-        ratingColor = 'green';
-      } else if (account.rating < 1600) {
-        // cyan
-        ratingColor = '#00C0C0';
-      } else if (account.rating < 2000) {
-        ratingColor = 'blue';
-      } else if (account.rating < 2400) {
-        // yellow
-        ratingColor = '#C0C000';
-      } else if (account.rating < 2800) {
-        ratingColor = 'orange';
-      } else {
-        ratingColor = 'red';
-      }
+      const ratingColor = getRatingColor(account.rating);
+
       return (
         <tr key={account.name}>
           <td>{idx + rankStart}</td>
@@ -51,8 +32,10 @@ export const AccountRankingTable: React.FC<AccountRankingTableProps> = ({
         </tr>
       );
     });
+
     return <tbody>{cols}</tbody>;
   })();
+
   return (
     <Table striped bordered hover>
       <thead>
@@ -67,6 +50,7 @@ export const AccountRankingTable: React.FC<AccountRankingTableProps> = ({
     </Table>
   );
 };
+
 export const RankingPage: React.FC = () => {
   const [accounts, setAccounts] = useState<AccountInfo[]>([]);
   const [nowPage, setNowPage] = useState(0);


### PR DESCRIPTION
・色を評価する処理を関数化して、functionに切り出しました。
・レート順位表と同じ処理でアカウントページのusernameにstyleをつけました。

アカウント画面でもレート順位表同様、レートに応じて色がつくようになります。