### PR TITLE
順位表の時間表示を一部修正　

### DIFF
--- a/frontend/src/components/RankingTable.tsx
+++ b/frontend/src/components/RankingTable.tsx
@@ -21,36 +21,85 @@ interface RankingTableRowProps {
   problems: ProblemInfo[];
 }
 
+type RowTemplateProps = {
+  // isMe: boolean;
+  ranking: number;
+  accountName: string;
+  score: number;
+  penalty: number;
+};
+const RowTemplate: React.VFC<RowTemplateProps> = ({
+  // isMe,
+  ranking,
+  accountName,
+  score,
+  penalty,
+}) => (
+  <>
+    {/*  <td className={isMe ? 'table-info' : undefined}></td> */}
+    <td className="align-middle text-center">{ranking}</td>
+    <td className="align-middle font-weight-bold">{accountName}</td>
+    <td className="align-middle text-center">
+      <div className="font-weight-bold text-primary">{score}</div>
+      <div className="text-muted">{formatSecondToMMSS(penalty)}</div>
+    </td>
+  </>
+);
+
+const PointAndAcTime = (time: number) => (
+  <td>
+    <p className={'contestPage-ranking-submitResult'}>AC</p>
+    <p className={'contestPage-ranking-submitTime'}>
+      {formatSecondToMMSS(time)}
+    </p>
+  </td>
+);
+
+type PlayerStatusProps = {
+  problemId: number;
+  point: number;
+  time: number;
+};
+const PlayerStatusOn_aProblem: React.VFC<PlayerStatusProps> = ({
+  problemId,
+  point,
+  time,
+}) => (
+  <td key={problemId} className="align-middle text-center">
+    <div className="font-weight-bold text-success">{point}</div>
+    <div className="text-muted">{formatSecondToMMSS(time)}</div>
+  </td>
+);
+
 export const RankingTableRow: React.FC<RankingTableRowProps> = ({
   account,
   isMe,
   problems,
 }) => {
-  const probElement = [];
-  for (let i = 0; i < problems.length; i++) {
-    if (account.acceptList.some((ac: any) => ac === i)) {
-      probElement.push(
-        <td>
-          <p className={'contestPage-ranking-submitResult'}>AC</p>
-          <p className={'contestPage-ranking-submitTime'}>
-            {formatSecondToMMSS(account.acceptTimeList[i])}
-          </p>
-        </td>
-      );
-    } else {
-      probElement.push(<td> </td>);
-    }
-  }
+  // 使われてない
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const probList = problems.map((_, i) =>
+    account.acceptList.some((ac: number) => ac === i) ? (
+      PointAndAcTime(account.acceptTimeList[i])
+    ) : (
+      <td> </td>
+    )
+  );
+
+  // account.acceptListが(true|false)[]で与えられたら処理は簡単になる
 
   return (
     <tr className={isMe ? 'table-info' : undefined}>
-      <td className="align-middle text-center">{account.ranking}</td>
-      <td className="align-middle font-weight-bold">{account.accountName}</td>
-      <td className="align-middle text-center">
-        <div className="font-weight-bold text-primary">{account.score}</div>
-        <div className="text-muted">{formatSecondToMMSS(account.penalty)}</div>
-      </td>
+      <RowTemplate
+        //  isMe={isMe}
+        ranking={account.ranking}
+        accountName={account.accountName}
+        score={account.score}
+        penalty={account.penalty}
+      />
+
       {problems.map((problems) => {
+        // 名前が衝突しています。動作が変わると嫌なのでとりあえずこのまま
         const i = account.acceptList.findIndex(
           (v) => v === problems.indexOfContest
         );
@@ -62,16 +111,12 @@ export const RankingTableRow: React.FC<RankingTableRowProps> = ({
           );
         }
         return (
-          <td key={problems.id} className="align-middle text-center">
-            <div className="font-weight-bold text-success">
-              {problems.point}
-            </div>
-            <div className="text-muted">
-              {formatSecondToMMSS(
-                account.acceptTimeList[problems.indexOfContest]
-              )}
-            </div>
-          </td>
+          <PlayerStatusOn_aProblem
+            key={problems.id}
+            problemId={problems.id}
+            point={problems.point}
+            time={account.acceptTimeList[problems.indexOfContest]}
+          />
         );
       })}
     </tr>

--- a/frontend/src/components/RankingTable.tsx
+++ b/frontend/src/components/RankingTable.tsx
@@ -48,7 +48,7 @@ export const RankingTableRow: React.FC<RankingTableRowProps> = ({
       <td className="align-middle font-weight-bold">{account.accountName}</td>
       <td className="align-middle text-center">
         <div className="font-weight-bold text-primary">{account.score}</div>
-        <div className="text-muted">{account.penalty}</div>
+        <div className="text-muted">{formatSecondToMMSS(account.penalty)}</div>
       </td>
       {problems.map((problems) => {
         const i = account.acceptList.findIndex(

--- a/frontend/src/components/RankingTable.tsx
+++ b/frontend/src/components/RankingTable.tsx
@@ -34,7 +34,6 @@ const RowTemplate: React.VFC<RowTemplateProps> = ({
   penalty,
 }) => (
   <>
-    {/*  <td className={isMe ? 'table-info' : undefined}></td> */}
     <td className="align-middle text-center">{ranking}</td>
     <td className="align-middle font-weight-bold">{accountName}</td>
     <td className="align-middle text-center">
@@ -44,21 +43,12 @@ const RowTemplate: React.VFC<RowTemplateProps> = ({
   </>
 );
 
-const PointAndAcTime = (time: number) => (
-  <td>
-    <p className={'contestPage-ranking-submitResult'}>AC</p>
-    <p className={'contestPage-ranking-submitTime'}>
-      {formatSecondToMMSS(time)}
-    </p>
-  </td>
-);
-
 type PlayerStatusProps = {
   problemId: number;
   point: number;
   time: number;
 };
-const PlayerStatusOn_aProblem: React.VFC<PlayerStatusProps> = ({
+const PlayerStatusOfProblem: React.VFC<PlayerStatusProps> = ({
   problemId,
   point,
   time,
@@ -74,16 +64,6 @@ export const RankingTableRow: React.FC<RankingTableRowProps> = ({
   isMe,
   problems,
 }) => {
-  // 使われてない
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const probList = problems.map((_, i) =>
-    account.acceptList.some((ac: number) => ac === i) ? (
-      PointAndAcTime(account.acceptTimeList[i])
-    ) : (
-      <td> </td>
-    )
-  );
-
   return (
     <tr className={isMe ? 'table-info' : undefined}>
       <RowTemplate
@@ -105,7 +85,7 @@ export const RankingTableRow: React.FC<RankingTableRowProps> = ({
           );
         }
         return (
-          <PlayerStatusOn_aProblem
+          <PlayerStatusOfProblem
             key={problem.id}
             problemId={problem.id}
             point={problem.point}

--- a/frontend/src/components/RankingTable.tsx
+++ b/frontend/src/components/RankingTable.tsx
@@ -98,24 +98,24 @@ export const RankingTableRow: React.FC<RankingTableRowProps> = ({
         penalty={account.penalty}
       />
 
-      {problems.map((problems) => {
+      {problems.map((problem) => {
         // 名前が衝突しています。動作が変わると嫌なのでとりあえずこのまま
-        const i = account.acceptList.findIndex(
-          (v) => v === problems.indexOfContest
+        const accountAcceptIdx = account.acceptList.findIndex(
+          (v) => v === problem.indexOfContest
         );
-        if (i === -1) {
+        if (accountAcceptIdx === -1) {
           return (
-            <td key={problems.id} className="align-middle text-center">
+            <td key={problem.id} className="align-middle text-center">
               -
             </td>
           );
         }
         return (
           <PlayerStatusOn_aProblem
-            key={problems.id}
-            problemId={problems.id}
-            point={problems.point}
-            time={account.acceptTimeList[problems.indexOfContest]}
+            key={problem.id}
+            problemId={problem.id}
+            point={problem.point}
+            time={account.acceptTimeList[problem.indexOfContest]}
           />
         );
       })}

--- a/frontend/src/components/RankingTable.tsx
+++ b/frontend/src/components/RankingTable.tsx
@@ -22,14 +22,12 @@ interface RankingTableRowProps {
 }
 
 type RowTemplateProps = {
-  // isMe: boolean;
   ranking: number;
   accountName: string;
   score: number;
   penalty: number;
 };
 const RowTemplate: React.VFC<RowTemplateProps> = ({
-  // isMe,
   ranking,
   accountName,
   score,
@@ -86,12 +84,9 @@ export const RankingTableRow: React.FC<RankingTableRowProps> = ({
     )
   );
 
-  // account.acceptListが(true|false)[]で与えられたら処理は簡単になる
-
   return (
     <tr className={isMe ? 'table-info' : undefined}>
       <RowTemplate
-        //  isMe={isMe}
         ranking={account.ranking}
         accountName={account.accountName}
         score={account.score}
@@ -99,7 +94,6 @@ export const RankingTableRow: React.FC<RankingTableRowProps> = ({
       />
 
       {problems.map((problem) => {
-        // 名前が衝突しています。動作が変わると嫌なのでとりあえずこのまま
         const accountAcceptIdx = account.acceptList.findIndex(
           (v) => v === problem.indexOfContest
         );

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -135,14 +135,14 @@ const RankingElement: React.FC<RankingElementProps> = ({
     getRanking();
   }
 
-  useEffect(() => {
-    getRanking();
-  }, []);
-
   let myRank = '';
   if (ranking?.requestAccountRank) {
     myRank = `順位: ${ranking.requestAccountRank}`;
   }
+
+  useEffect(() => {
+    getRanking();
+  }, []);
 
   return (
     <>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -38,16 +38,18 @@ export interface RankingInfo {
 /**
  * 順位表に表示するためのアカウント情報
  */
+// AccountRankingInfoとRankingInfoAccountの区別が付きづらい User_StandingDataなどは？
+// ユーザーの順位に関係するデータだとすぐわかるようにしたいです
 export interface RankingInfoAccount {
   accountName: string;
   /**
    * ACした問題リスト
    */
-  acceptList: unknown[];
+  acceptList: number[];
   /**
    * このアカウントの現在順位
    */
-  ranking: any;
+  ranking: number;
   /**
    * 提出までに経過した秒数
    */


### PR DESCRIPTION
close #170
コンテストページ得点欄の時間表示のフォーマットを変えました。
コミットメッセージで間違えてますが、フォーマットは分分：秒秒ですね。中身は大丈夫です。

周辺の型定義を追加、コンポーネントを切り出しました。
reactはコンポーネントをなるべく小さく分けて、レイアウト（ビュー）部分とロジック部分を独立させることがベストプラクティスのようです。コンポーネントを細かく分けることはパフォーマンス戦略としても優れていますし、独立性を高めることはメンテの容易さにも繋がります。

@rdrgn PRのリファクタリング部分で#133の作業とコンフリクトしている部分があれば、ご自身のファイルの方を優先してくださって大丈夫です！コンフリクト解決は面倒だと思うので……
