### PR TITLE
[frontend] オートフォーカス追加/コンポーネント分割

### DIFF
--- a/frontend/src/components/RankingTable.tsx
+++ b/frontend/src/components/RankingTable.tsx
@@ -192,7 +192,7 @@ export const RankingTable: React.FC<Props> = ({
     [ranking.acPerSubmit]
   );
 
-  if (problems.length !== ranking.acPerSubmit.length) {
+  if (problems.length && problems.length !== ranking.acPerSubmit.length) {
     return <Alert variant="danger">Error</Alert>;
   }
 

--- a/frontend/src/functions/createEnglishIndex.ts
+++ b/frontend/src/functions/createEnglishIndex.ts
@@ -1,0 +1,12 @@
+export const createEnglishIndex = (index: number, max_width: number) => {
+  if (index > max_width)
+    throw new Error('インデックスは総問題数以下の数であるべきです');
+
+  const ALPHABETS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+  const ALPHABETS_NUM = 26;
+  let alph = ALPHABETS[index % ALPHABETS_NUM];
+  if (max_width > ALPHABETS_NUM && index >= ALPHABETS_NUM) {
+    alph += Math.floor(index / ALPHABETS_NUM);
+  }
+  return alph;
+};

--- a/frontend/src/functions/findContestIdFromPath.ts
+++ b/frontend/src/functions/findContestIdFromPath.ts
@@ -1,0 +1,8 @@
+export const findContestIdFromPath = () => {
+  const splitPath = window.location.pathname.split('/');
+  const index = splitPath.indexOf('contest');
+  if (index === -1 || index === splitPath.length) {
+    throw new Error('pathにcontestを含んでいません');
+  }
+  return splitPath[index + 1];
+};

--- a/frontend/src/functions/getContestId.ts
+++ b/frontend/src/functions/getContestId.ts
@@ -1,4 +1,0 @@
-export function getContestId() {
-  const splitPath = window.location.pathname.split('/');
-  return splitPath.slice(-1)[0];
-}

--- a/frontend/src/functions/getContestId.ts
+++ b/frontend/src/functions/getContestId.ts
@@ -1,0 +1,4 @@
+export function getContestId() {
+  const splitPath = window.location.pathname.split('/');
+  return splitPath.slice(-1)[0];
+}

--- a/frontend/src/pages/ContestEditPage.tsx
+++ b/frontend/src/pages/ContestEditPage.tsx
@@ -14,22 +14,24 @@ import {
   patchContestInfo,
   putContestInfo,
 } from '../functions/HttpRequest';
+import { findContestIdFromPath } from '../functions/findContestIdFromPath';
 import { getCookie } from '../functions/getCookie';
 import { ContestCreator } from '../types';
-
 // URL: /contest/$contestName/edit
 
-function getContestId() {
-  const splitPath = window.location.pathname.split('/');
-  return splitPath.slice()[2];
-}
 class EditProblemInfo {
   statement: string;
   id: number;
   point: number | undefined;
   answer: string[];
   isQuiz: boolean;
-  constructor(statement: string, id: number, point: number, answer: string[], izQuiz: boolean) {
+  constructor(
+    statement: string,
+    id: number,
+    point: number,
+    answer: string[],
+    izQuiz: boolean
+  ) {
     this.statement = statement;
     this.id = id;
     this.point = point;
@@ -54,7 +56,7 @@ const EditProblemsElement: React.FC<EditProblemsElementProps> = ({
     const newProblems = [...problems];
     newProblems[idx].isQuiz = isQuiz;
     setProblems(newProblems);
-  }
+  };
   const updateProblemPoint = (idx: number, point: string) => {
     const newProblems = [...problems];
     let newPoint: number | undefined = parseInt(point);
@@ -96,60 +98,60 @@ const EditProblemsElement: React.FC<EditProblemsElementProps> = ({
       </Popover>
     );
     return (
-        <Form.Row key={problem.id}>
-          <Col>
-            <Form.Label>問題文</Form.Label>
-            <InputGroup className={'mb-3'}>
-              <Form.Control
-                  placeholder={'〇〇な△△な〜んだ？'}
-                  value={problem.statement}
-                  onChange={(e) => updateProblemStatement(idx, e.target.value)}
-              />
-            </InputGroup>
-          </Col>
-          <Col>
-            <Form.Label>点数</Form.Label>
-            <InputGroup className={'mb-3'}>
-              <Form.Control
-                  type={'number'}
-                  value={problem.point}
-                  onChange={(e) => updateProblemPoint(idx, e.target.value)}
-              />
-            </InputGroup>
-          </Col>
-          <Col>
-            <Form.Label>Quizモード</Form.Label>
-            <Form.Switch
-                id={`${problem.id} switch`}
-                type={'switch'}
-                label={'off/on'}
-                defaultChecked={problem.isQuiz}
-                onChange={(e) => {
-                  updateProblemQuizMode(idx, e.target.checked)}
-                }
+      <Form.Row key={problem.id}>
+        <Col>
+          <Form.Label>問題文</Form.Label>
+          <InputGroup className={'mb-3'}>
+            <Form.Control
+              placeholder={'〇〇な△△な〜んだ？'}
+              value={problem.statement}
+              onChange={(e) => updateProblemStatement(idx, e.target.value)}
             />
-          </Col>
-          <Col>
-            <br />
-            <OverlayTrigger
-                rootClose={true}
-                trigger={'click'}
-                placement={'right'}
-                overlay={popOver}
-            >
-              <Button variant={'primary'}>答え編集</Button>
-            </OverlayTrigger>
-          </Col>
-          <Col>
-            <br />
-            <button type={'button'} onClick={addProblem}>
-              +
-            </button>
-            <button type={'button'} onClick={() => eraseProblem(problem.id)}>
-              -
-            </button>
-          </Col>
-        </Form.Row>
+          </InputGroup>
+        </Col>
+        <Col>
+          <Form.Label>点数</Form.Label>
+          <InputGroup className={'mb-3'}>
+            <Form.Control
+              type={'number'}
+              value={problem.point}
+              onChange={(e) => updateProblemPoint(idx, e.target.value)}
+            />
+          </InputGroup>
+        </Col>
+        <Col>
+          <Form.Label>Quizモード</Form.Label>
+          <Form.Switch
+            id={`${problem.id} switch`}
+            type={'switch'}
+            label={'off/on'}
+            defaultChecked={problem.isQuiz}
+            onChange={(e) => {
+              updateProblemQuizMode(idx, e.target.checked);
+            }}
+          />
+        </Col>
+        <Col>
+          <br />
+          <OverlayTrigger
+            rootClose={true}
+            trigger={'click'}
+            placement={'right'}
+            overlay={popOver}
+          >
+            <Button variant={'primary'}>答え編集</Button>
+          </OverlayTrigger>
+        </Col>
+        <Col>
+          <br />
+          <button type={'button'} onClick={addProblem}>
+            +
+          </button>
+          <button type={'button'} onClick={() => eraseProblem(problem.id)}>
+            -
+          </button>
+        </Col>
+      </Form.Row>
     );
   });
   return <div>{listGroups}</div>;
@@ -167,7 +169,7 @@ export const ContestEditPage: React.FC = () => {
   const [startTime, setStartTime] = useState<number>(0);
   useEffect(() => {
     (async () => {
-      const contestId = getContestId();
+      const contestId = findContestIdFromPath();
       const contestInfo = await getContestInfo(contestId).catch(() => null);
       const contestProblems = await getContestProblems(contestId).catch(
         () => null
@@ -196,11 +198,11 @@ export const ContestEditPage: React.FC = () => {
           answers[idx].push('');
         }
         return new EditProblemInfo(
-            problem.statement,
-            idx,
-            problem.point,
-            answers[idx],
-            problem.quiz
+          problem.statement,
+          idx,
+          problem.point,
+          answers[idx],
+          problem.quiz
         );
       });
       if (problems.length === 0) {
@@ -236,13 +238,18 @@ export const ContestEditPage: React.FC = () => {
         statement: problem.statement,
         point: point,
         answer: problem.answer,
-        isQuiz: problem.isQuiz
+        isQuiz: problem.isQuiz,
       };
     });
-    updateFunction(getContestId(), parseInt(penalty), statement, sendProblems)
+    updateFunction(
+      findContestIdFromPath(),
+      parseInt(penalty),
+      statement,
+      sendProblems
+    )
       .then(() => {
         alert('コンテストの編集が完了しました');
-        window.location.href = `/contest/${getContestId()}`;
+        window.location.href = `/contest/${findContestIdFromPath()}`;
       })
       .catch((e) => {
         alert('コンテストの編集に失敗しました');
@@ -253,7 +260,9 @@ export const ContestEditPage: React.FC = () => {
   return (
     <div>
       <p>コンテスト開始後に点数、答え、問題数は変更できません</p>
-      <p>Quizモードにした場合、順位として有効な提出は最初の一回のみとなります</p>
+      <p>
+        Quizモードにした場合、順位として有効な提出は最初の一回のみとなります
+      </p>
       <p>問題を選択肢形式にする場合等にご利用下さい</p>
       <Form>
         <Form.Row>

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -1,373 +1,23 @@
-import PropTypes from 'prop-types';
 import React, { useEffect, useState } from 'react';
 import Button from 'react-bootstrap/Button';
-import Form from 'react-bootstrap/Form';
-import Tab from 'react-bootstrap/Tab';
-import Table from 'react-bootstrap/Table';
-import Tabs from 'react-bootstrap/Tabs';
 import { Link } from 'react-router-dom';
-import { PagingElement } from '../components/PagingElement';
-import { RankingTable } from '../components/RankingTable';
-import { useAuthentication } from '../contexts/AuthenticationContext';
 import {
   getAccountInformation,
   getContestInfo,
   getContestProblems,
-  getRankingInfo,
   getSubmission,
-  postSubmission,
   updateContestRating,
 } from '../functions/HttpRequest';
+import { getContestId } from '../functions/getContestId';
+
 import { getCookie } from '../functions/getCookie';
-import { ProblemInfo, RankingInfo, SubmissionInfo } from '../types';
+import { ProblemInfo, SubmissionInfo } from '../types';
+import { ProblemsTab } from './contestPage/ProblemsTab';
 import './ContestPage.css';
 
-const KEY_OF_MY_SUBMISSIONS = 'mySubmit';
-
 // URL: /contest/$contestId
-
-function createEnglishIndex(index: number, num: number) {
-  const ALPHABETS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
-  const ALPHABETS_NUM = 26;
-  let res = ALPHABETS[index % ALPHABETS_NUM];
-  if (num > ALPHABETS_NUM) {
-    res += index / ALPHABETS_NUM;
-  }
-  return res;
-}
-
-function getContestId() {
-  const splitPath = window.location.pathname.split('/');
-  return splitPath.slice(-1)[0];
-}
-
-interface SubmissionTableProps {
-  problemNum: number;
-  submissions: any[];
-}
-
-const SubmissionTable: React.FC<SubmissionTableProps> = ({
-  problemNum,
-  submissions,
-}) => {
-  const [displaySubmissions, setDisplaySubmissions] = useState<any>([]);
-
-  if (submissions.length === 0) {
-    return <div />;
-  }
-
-  const SUBMISSIONS_IN_ONE_PAGE = 5;
-  const pageNum = Math.ceil(submissions.length / SUBMISSIONS_IN_ONE_PAGE);
-  const changeDisplaySubmissions = (page: any) => {
-    const newSubmissions = submissions.filter(
-      (_: any, idx: number) =>
-        page * SUBMISSIONS_IN_ONE_PAGE <= idx &&
-        idx < (page + 1) * SUBMISSIONS_IN_ONE_PAGE
-    );
-    setDisplaySubmissions(newSubmissions);
-  };
-
-  const createTableBody = () => {
-    /**
-     * @param {Object} submit - 提出情報
-     * @param {String} submit.statement - 提出した際の答案
-     * @param {String} submit.result - 提出結果
-     * @param {String} submit.submitTimeAMPM - 提出時間のフォーマット済の文字列
-     */
-    return displaySubmissions.map((submit: any, idx: number) => {
-      return (
-        <tr key={idx}>
-          <td key={idx + 'idx'}>
-            {createEnglishIndex(submit.indexOfContest, problemNum)}
-          </td>
-          <td key={idx + 'stm'}>{submit.statement}</td>
-          <td key={idx + 'res'}>{submit.result}</td>
-          <td key={idx + 'time'}>{submit.submitTimeAMPM}</td>
-        </tr>
-      );
-    });
-  };
-
-  return (
-    <div>
-      <Table striped bordered hover>
-        <thead>
-          <tr>
-            <th>問題</th>
-            <th>提出</th>
-            <th>結果</th>
-            <th>提出時間</th>
-          </tr>
-        </thead>
-        <tbody>{createTableBody()}</tbody>
-      </Table>
-      <PagingElement pageNum={pageNum} pageChanged={changeDisplaySubmissions} />
-    </div>
-  );
-};
-
-SubmissionTable.propTypes = {
-  problemNum: PropTypes.number.isRequired,
-  submissions: PropTypes.array.isRequired,
-};
-
-interface RankingElementProps {
-  problems: ProblemInfo[];
-  rankingVersion: number;
-}
-
-const RankingElement: React.FC<RankingElementProps> = ({
-  problems,
-  rankingVersion,
-}) => {
-  const { accountName } = useAuthentication();
-  const [ranking, setRanking] = useState<RankingInfo | null>(null);
-  const [nowRankingVersion, setNowRankingVersion] = useState(0);
-
-  const getRanking = () => {
-    getRankingInfo(null, getContestId()).then((rankingInfo) => {
-      setRanking(rankingInfo);
-    });
-  };
-
-  if (nowRankingVersion !== rankingVersion) {
-    setNowRankingVersion(rankingVersion);
-    getRanking();
-  }
-
-  useEffect(() => {
-    getRanking();
-  }, []);
-
-  let myRank = '';
-  if (ranking?.requestAccountRank) {
-    myRank = `順位: ${ranking.requestAccountRank}`;
-  }
-
-  return (
-    <>
-      <p>{myRank}</p>
-      {ranking && (
-        <RankingTable
-          myAccountName={accountName}
-          problems={problems}
-          ranking={ranking}
-        />
-      )}
-      <Button onClick={getRanking} variant="secondary">
-        更新
-      </Button>
-    </>
-  );
-};
-
-RankingElement.propTypes = {
-  problems: PropTypes.array.isRequired,
-  rankingVersion: PropTypes.number.isRequired,
-};
-
-interface ProblemsTabProps {
-  contestName: string;
-  problems: ProblemInfo[];
-  submissions: SubmissionInfo[];
-}
-interface SubmitFormProps {
-  tabKey: string;
-  answerInput: React.RefObject<HTMLInputElement>;
-  submitAnswer: () => void;
-  nowSubmissions: any[];
-  lengthOfTab: number;
-}
-
-const AnswerSubmitForm: React.VFC<SubmitFormProps> = ({
-  tabKey,
-  answerInput,
-  submitAnswer,
-  nowSubmissions,
-  lengthOfTab,
-}) => {
-  if (tabKey !== KEY_OF_MY_SUBMISSIONS) {
-    const handleKeyDown = (
-      e: React.KeyboardEvent<HTMLInputElement> | undefined
-    ) => {
-      if (e?.key === 'Enter' && e?.ctrlKey) {
-        // or just (e.key==="Enter")
-        submitAnswer();
-      }
-    };
-
-    return (
-      <div>
-        <Form.Label>答え</Form.Label>
-        <Form.Control
-          type={'text'}
-          onKeyDown={handleKeyDown}
-          ref={answerInput}
-          placeholder="Ctrl+Enterで提出"
-        />
-        <Button type={'primary'} onClick={submitAnswer}>
-          提出
-        </Button>
-      </div>
-    );
-  } else {
-    return (
-      <SubmissionTable submissions={nowSubmissions} problemNum={lengthOfTab} />
-    );
-  }
-};
-
-const ProblemsTab: React.FC<ProblemsTabProps> = ({ problems, submissions }) => {
-  const answerInput = React.createRef<HTMLInputElement>();
-  const [comment, setComment] = useState('');
-  const [key, setKey] = useState(KEY_OF_MY_SUBMISSIONS);
-  const [changeColor, setChangeColor] = useState(true);
-  const [firstTabRender, setFirstTabRender] = useState(false);
-  const [nowSubmissions, setNowSubmission] = useState<any[]>([]);
-  const [rankingVersion, setRankingVersion] = useState(0);
-  const TAB_ID = 'tabId';
-  if (
-    !firstTabRender &&
-    ((problems.length !== 0 && submissions.length !== 0) ||
-      nowSubmissions.length !== 0)
-  ) {
-    setFirstTabRender(true);
-  }
-
-  const submitAnswer = (): void => {
-    if (answerInput.current?.value === '') {
-      return setComment('答えが空です');
-    }
-    if (answerInput.current?.value.indexOf(':') !== -1) {
-      return setComment(': を含む答えは提出できません');
-    }
-    setComment('');
-
-    postSubmission(getContestId(), key, answerInput.current.value)
-      .then((submitResult) => {
-        const newSubmissions = nowSubmissions.slice();
-        newSubmissions.unshift(submitResult);
-        setNowSubmission(newSubmissions);
-        setComment(submitResult.result);
-        // RankingElement再読込のため、バージョニング
-        setRankingVersion(rankingVersion + 1);
-      })
-      .catch((e) => {
-        if (e.message === '403') {
-          setComment('5秒間隔を空けて提出して下さい');
-        } else if (e.message === '400') {
-          setComment('ログインして下さい');
-        } else {
-          setComment('提出に失敗しました 再ログインを試してみて下さい');
-        }
-      });
-  };
-
-  const getProblemTabList = () => {
-    return problems.map((problem: ProblemInfo, index: number) => {
-      const problemTitle = createEnglishIndex(index, problems.length);
-      return (
-        <Tab
-          eventKey={index.toString()}
-          key={problem.indexOfContest}
-          title={problemTitle}
-        >
-          <h6>{'point: ' + problem.point}</h6>
-          <div className={'div-pre'}>
-            <p>{problem.statement}</p>
-          </div>
-        </Tab>
-      );
-    });
-  };
-
-  const selectTab = (key: any) => {
-    setComment('');
-    setChangeColor(true);
-    setKey((key ?? '').toString());
-    if (answerInput.current) {
-      answerInput.current.value = '';
-    }
-  };
-
-  useEffect(() => {
-    const getSubmitResultArray = () => {
-      //初期化時はprops、そうでない場合nowSubmissionsが新しい値 更新されている場合、要素数が多い
-      let useSubmissions;
-      if (nowSubmissions.length < submissions.length) {
-        useSubmissions = submissions;
-      } else {
-        useSubmissions = nowSubmissions;
-      }
-      const tryingArray = new Array(problems.length).fill('NO_SUB');
-      useSubmissions.map((submit: any) => {
-        if (submit.result === 'ACCEPTED') {
-          tryingArray[submit.indexOfContest] = 'ACCEPTED';
-        } else if (submit.result === 'WRONG_ANSWER') {
-          if (tryingArray[submit.indexOfContest] === 'NO_SUB') {
-            tryingArray[submit.indexOfContest] = 'WRONG_ANSWER';
-          }
-        }
-      });
-      return tryingArray;
-    };
-
-    const setColor = () => {
-      const submitResult = getSubmitResultArray();
-      problems.map((_: ProblemInfo, index: number) => {
-        const element = document.getElementById(TAB_ID + '-tab-' + index);
-        element?.classList.remove('bg-success', 'text-white', 'bg-warning');
-        if (submitResult) {
-          switch (submitResult[index]) {
-            case 'ACCEPTED':
-              element?.classList.add('bg-success');
-              element?.classList.add('text-white');
-              break;
-            case 'WRONG_ANSWER':
-              element?.classList.add('bg-warning');
-              element?.classList.add('text-white');
-              break;
-          }
-        }
-      });
-    };
-    setColor();
-    setChangeColor(false);
-    setFirstTabRender(false);
-    //初期化時のみ
-    if (nowSubmissions.length === 0) {
-      setNowSubmission(submissions);
-    }
-  }, [changeColor, firstTabRender]);
-
-  return (
-    <div>
-      <Tabs id={TAB_ID} activeKey={key} onSelect={selectTab}>
-        {getProblemTabList()}
-        <Tab eventKey={'mySubmit'} key={'mySubmit'} title={'自分の提出'} />
-      </Tabs>
-      <AnswerSubmitForm
-        tabKey={key}
-        answerInput={answerInput}
-        submitAnswer={submitAnswer}
-        nowSubmissions={nowSubmissions}
-        lengthOfTab={problems.length}
-      />
-      <p>{comment}</p>
-      <hr />
-      <RankingElement problems={problems} rankingVersion={rankingVersion} />
-    </div>
-  );
-};
-
-ProblemsTab.propTypes = {
-  contestName: PropTypes.string.isRequired,
-  problems: PropTypes.array.isRequired,
-  submissions: PropTypes.array.isRequired,
-};
-
 export const ContestPage: React.FC = () => {
-  const [contestName, setContestName] = useState('コンテストが見つかりません');
+  const [contestName, setContestName] = useState('');
   const [statement, setStatement] = useState('');
   const [time, setTime] = useState('');
   const [submissions, setSubmissions] = useState<SubmissionInfo[]>([]);
@@ -392,7 +42,7 @@ export const ContestPage: React.FC = () => {
 
   useEffect(() => {
     const contestId = getContestId();
-    (async () => {
+    const asyncFunctions = async () => {
       const contestInfo = await getContestInfo(contestId).catch(() => null);
       if (contestInfo === null) {
         setContestName('コンテストが見つかりません');
@@ -428,7 +78,9 @@ export const ContestPage: React.FC = () => {
       setTime(`${contestInfo.startTimeAMPM} ~ ${contestInfo.endTimeAMPM}`);
       setProblems(problems);
       setSubmissions(submissions);
-    })();
+    };
+
+    asyncFunctions();
   }, []);
 
   return (

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -440,13 +440,6 @@ export const ContestPage: React.FC = () => {
       >
         {'レート更新'}
       </Button>
-      <Button
-        onClick={ratingUpdate}
-        variant={'info'}
-        style={ratingUpdateButtonStyle}
-      >
-        {'レート更新'}
-      </Button>
       <Link to={`/contest/${getContestId()}/edit`}>
         <Button variant={'info'} style={contestEditButtonStyle}>
           {'コンテスト編集'}

--- a/frontend/src/pages/ContestPage.tsx
+++ b/frontend/src/pages/ContestPage.tsx
@@ -8,7 +8,7 @@ import {
   getSubmission,
   updateContestRating,
 } from '../functions/HttpRequest';
-import { getContestId } from '../functions/getContestId';
+import { findContestIdFromPath } from '../functions/findContestIdFromPath';
 
 import { getCookie } from '../functions/getCookie';
 import { ProblemInfo, SubmissionInfo } from '../types';
@@ -29,7 +29,7 @@ export const ContestPage: React.FC = () => {
     display: 'none',
   });
   const ratingUpdate = () => {
-    updateContestRating(getContestId())
+    updateContestRating(findContestIdFromPath())
       .then(() => {
         alert('レート更新が完了しました');
         location.reload();
@@ -41,7 +41,7 @@ export const ContestPage: React.FC = () => {
   };
 
   useEffect(() => {
-    const contestId = getContestId();
+    const contestId = findContestIdFromPath();
     const asyncFunctions = async () => {
       const contestInfo = await getContestInfo(contestId).catch(() => null);
       if (contestInfo === null) {
@@ -53,7 +53,7 @@ export const ContestPage: React.FC = () => {
       const cookieArray = getCookie();
       if (cookieArray['_sforce_account_name']) {
         const accountName = cookieArray['_sforce_account_name'];
-        submissions = await getSubmission(getContestId(), accountName);
+        submissions = await getSubmission(findContestIdFromPath(), accountName);
         const accountInfo = await getAccountInformation(accountName);
         if (
           accountInfo.auth === 'ADMINISTER' &&
@@ -92,7 +92,7 @@ export const ContestPage: React.FC = () => {
       >
         {'レート更新'}
       </Button>
-      <Link to={`/contest/${getContestId()}/edit`}>
+      <Link to={`/contest/${findContestIdFromPath()}/edit`}>
         <Button variant={'info'} style={contestEditButtonStyle}>
           {'コンテスト編集'}
         </Button>

--- a/frontend/src/pages/contestPage/AnswerSubmitForm.tsx
+++ b/frontend/src/pages/contestPage/AnswerSubmitForm.tsx
@@ -1,0 +1,32 @@
+import React, { VFC, RefObject, KeyboardEvent } from 'react';
+import Button from 'react-bootstrap/Button';
+import Form from 'react-bootstrap/Form';
+
+interface Props {
+  answerInput: RefObject<HTMLInputElement>;
+  submitAnswer: () => void;
+}
+
+export const AnswerSubmitForm: VFC<Props> = ({ answerInput, submitAnswer }) => {
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement> | undefined) => {
+    if (e?.key === 'Enter' && e?.ctrlKey) {
+      // or just (e.key==="Enter")
+      submitAnswer();
+    }
+  };
+
+  return (
+    <div>
+      <Form.Label>答え</Form.Label>
+      <Form.Control
+        type={'text'}
+        onKeyDown={handleKeyDown}
+        ref={answerInput}
+        placeholder="Ctrl+Enterで提出"
+      />
+      <Button type={'primary'} onClick={submitAnswer}>
+        提出
+      </Button>
+    </div>
+  );
+};

--- a/frontend/src/pages/contestPage/ProblemsTab.tsx
+++ b/frontend/src/pages/contestPage/ProblemsTab.tsx
@@ -3,7 +3,7 @@ import Tab from 'react-bootstrap/Tab';
 import Tabs from 'react-bootstrap/Tabs';
 import { postSubmission } from '../../functions/HttpRequest';
 import { createEnglishIndex } from '../../functions/createEnglishIndex';
-import { getContestId } from '../../functions/getContestId';
+import { findContestIdFromPath } from '../../functions/findContestIdFromPath';
 import { ProblemInfo, SubmissionInfo } from '../../types';
 import { SubmissionTable } from '../contestPage/SubmissionTable';
 import { AnswerSubmitForm } from './AnswerSubmitForm';
@@ -41,7 +41,7 @@ export const ProblemsTab: VFC<Props> = ({ problems, submissions }) => {
     }
     setComment('');
 
-    postSubmission(getContestId(), key, answerInput.current.value)
+    postSubmission(findContestIdFromPath(), key, answerInput.current.value)
       .then((submitResult) => {
         const newSubmissions = nowSubmissions.slice();
         newSubmissions.unshift(submitResult);

--- a/frontend/src/pages/contestPage/ProblemsTab.tsx
+++ b/frontend/src/pages/contestPage/ProblemsTab.tsx
@@ -1,0 +1,169 @@
+import React, { VFC, createRef, useState, useEffect } from 'react';
+import Tab from 'react-bootstrap/Tab';
+import Tabs from 'react-bootstrap/Tabs';
+import { postSubmission } from '../../functions/HttpRequest';
+import { createEnglishIndex } from '../../functions/createEnglishIndex';
+import { getContestId } from '../../functions/getContestId';
+import { ProblemInfo, SubmissionInfo } from '../../types';
+import { SubmissionTable } from '../contestPage/SubmissionTable';
+import { AnswerSubmitForm } from './AnswerSubmitForm';
+import { RankingElement } from './RankingElement';
+
+interface Props {
+  contestName: string;
+  problems: ProblemInfo[];
+  submissions: SubmissionInfo[];
+}
+const KEY_OF_MY_SUBMISSIONS = 'mySubmit';
+export const ProblemsTab: VFC<Props> = ({ problems, submissions }) => {
+  const answerInput = createRef<HTMLInputElement>();
+  const [comment, setComment] = useState('');
+  const [key, setKey] = useState(KEY_OF_MY_SUBMISSIONS);
+  const [changeColor, setChangeColor] = useState(true);
+  const [firstTabRender, setFirstTabRender] = useState(false);
+  const [nowSubmissions, setNowSubmission] = useState<any[]>([]);
+  const [rankingVersion, setRankingVersion] = useState(0);
+  const TAB_ID = 'tabId';
+  if (
+    !firstTabRender &&
+    ((problems.length !== 0 && submissions.length !== 0) ||
+      nowSubmissions.length !== 0)
+  ) {
+    setFirstTabRender(true);
+  }
+
+  const submitAnswer = (): void => {
+    if (answerInput.current?.value === '') {
+      return setComment('答えが空です');
+    }
+    if (answerInput.current?.value.indexOf(':') !== -1) {
+      return setComment(': を含む答えは提出できません');
+    }
+    setComment('');
+
+    postSubmission(getContestId(), key, answerInput.current.value)
+      .then((submitResult) => {
+        const newSubmissions = nowSubmissions.slice();
+        newSubmissions.unshift(submitResult);
+        setNowSubmission(newSubmissions);
+        setComment(submitResult.result);
+        // RankingElement再読込のため、バージョニング
+        setRankingVersion(rankingVersion + 1);
+      })
+      .catch((e) => {
+        if (e.message === '403') {
+          setComment('5秒間隔を空けて提出して下さい'); // このあたりの実装はクライアントで責任をもちたい
+        } else if (e.message === '400') {
+          setComment('ログインして下さい');
+        } else {
+          setComment('提出に失敗しました 再ログインを試してみて下さい');
+        }
+      });
+  };
+
+  const getProblemTabList = () => {
+    return problems.map((problem, index: number) => {
+      const problemTitle = createEnglishIndex(index, problems.length);
+
+      return (
+        <Tab
+          eventKey={index.toString()}
+          key={problem.indexOfContest}
+          title={problemTitle}
+        >
+          <h6>{'point: ' + problem.point}</h6>
+          <div className={'div-pre'}>
+            <p>{problem.statement}</p>
+          </div>
+        </Tab>
+      );
+    });
+  };
+
+  const selectTab = (key: any) => {
+    setComment('');
+    setChangeColor(true);
+    setKey((key ?? '').toString());
+    if (answerInput.current) {
+      answerInput.current.value = '';
+    }
+  };
+
+  useEffect(() => {
+    const getSubmitResultArray = () => {
+      //初期化時はprops、そうでない場合nowSubmissionsが新しい値 更新されている場合、要素数が多い
+      let useSubmissions;
+      if (nowSubmissions.length < submissions.length) {
+        useSubmissions = submissions;
+      } else {
+        useSubmissions = nowSubmissions;
+      }
+      const tryingArray = new Array(problems.length).fill('NO_SUB');
+      useSubmissions.map((submit: any) => {
+        if (submit.result === 'ACCEPTED') {
+          tryingArray[submit.indexOfContest] = 'ACCEPTED';
+        } else if (submit.result === 'WRONG_ANSWER') {
+          if (tryingArray[submit.indexOfContest] === 'NO_SUB') {
+            tryingArray[submit.indexOfContest] = 'WRONG_ANSWER';
+          }
+        }
+      });
+      return tryingArray;
+    };
+
+    const setColor = () => {
+      const submitResult = getSubmitResultArray();
+      problems.map((_: ProblemInfo, index: number) => {
+        const element = document.getElementById(TAB_ID + '-tab-' + index);
+        element?.classList.remove('bg-success', 'text-white', 'bg-warning');
+        if (submitResult) {
+          switch (submitResult[index]) {
+            case 'ACCEPTED':
+              element?.classList.add('bg-success');
+              element?.classList.add('text-white');
+              break;
+            case 'WRONG_ANSWER':
+              element?.classList.add('bg-warning');
+              element?.classList.add('text-white');
+              break;
+          }
+        }
+      });
+    };
+    setColor();
+    setChangeColor(false);
+    setFirstTabRender(false);
+    //初期化時のみ
+    if (nowSubmissions.length === 0) {
+      setNowSubmission(submissions);
+    }
+  }, [changeColor, firstTabRender]);
+  useEffect(() => {
+    const ele = answerInput.current;
+    ele?.focus();
+  }, [key]);
+
+  return (
+    <div>
+      <Tabs id={TAB_ID} activeKey={key} onSelect={selectTab}>
+        {getProblemTabList()}
+        <Tab eventKey={'mySubmit'} key={'mySubmit'} title={'自分の提出'} />
+      </Tabs>
+      {key !== KEY_OF_MY_SUBMISSIONS ? (
+        <AnswerSubmitForm
+          answerInput={answerInput}
+          submitAnswer={submitAnswer}
+        />
+      ) : (
+        <SubmissionTable
+          submissions={nowSubmissions}
+          problemNum={problems.length}
+        />
+      )}
+
+      <p>{comment}</p>
+      <hr />
+      <RankingElement problems={problems} rankingVersion={rankingVersion} />
+    </div>
+  );
+};

--- a/frontend/src/pages/contestPage/RankingElement.tsx
+++ b/frontend/src/pages/contestPage/RankingElement.tsx
@@ -3,7 +3,7 @@ import Button from 'react-bootstrap/Button';
 import { RankingTable } from '../../components/RankingTable';
 import { useAuthentication } from '../../contexts/AuthenticationContext';
 import { getRankingInfo } from '../../functions/HttpRequest';
-import { getContestId } from '../../functions/getContestId';
+import { findContestIdFromPath } from '../../functions/findContestIdFromPath';
 import { ProblemInfo, RankingInfo } from '../../types';
 interface Props {
   problems: ProblemInfo[];
@@ -19,7 +19,7 @@ export const RankingElement: React.FC<Props> = ({
   const [nowRankingVersion, setNowRankingVersion] = useState(0);
 
   const getRanking = () => {
-    getRankingInfo(null, getContestId()).then((rankingInfo) => {
+    getRankingInfo(null, findContestIdFromPath()).then((rankingInfo) => {
       setRanking(rankingInfo);
     });
   };

--- a/frontend/src/pages/contestPage/RankingElement.tsx
+++ b/frontend/src/pages/contestPage/RankingElement.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from 'react';
+import Button from 'react-bootstrap/Button';
+import { RankingTable } from '../../components/RankingTable';
+import { useAuthentication } from '../../contexts/AuthenticationContext';
+import { getRankingInfo } from '../../functions/HttpRequest';
+import { getContestId } from '../../functions/getContestId';
+import { ProblemInfo, RankingInfo } from '../../types';
+interface Props {
+  problems: ProblemInfo[];
+  rankingVersion: number;
+}
+
+export const RankingElement: React.FC<Props> = ({
+  problems,
+  rankingVersion,
+}) => {
+  const { accountName } = useAuthentication();
+  const [ranking, setRanking] = useState<RankingInfo | null>(null);
+  const [nowRankingVersion, setNowRankingVersion] = useState(0);
+
+  const getRanking = () => {
+    getRankingInfo(null, getContestId()).then((rankingInfo) => {
+      setRanking(rankingInfo);
+    });
+  };
+
+  if (nowRankingVersion !== rankingVersion) {
+    setNowRankingVersion(rankingVersion);
+    getRanking();
+  }
+
+  useEffect(() => {
+    getRanking();
+  }, []);
+
+  let myRank = '';
+  if (ranking?.requestAccountRank) {
+    myRank = `順位: ${ranking.requestAccountRank}`;
+  }
+
+  return (
+    <>
+      <p>{myRank}</p>
+      {ranking && (
+        <RankingTable
+          myAccountName={accountName}
+          problems={problems}
+          ranking={ranking}
+        />
+      )}
+      <Button onClick={getRanking} variant="secondary">
+        更新
+      </Button>
+    </>
+  );
+};

--- a/frontend/src/pages/contestPage/SubmissionTable.tsx
+++ b/frontend/src/pages/contestPage/SubmissionTable.tsx
@@ -1,0 +1,75 @@
+import PropTypes from 'prop-types';
+import React, { useState } from 'react';
+import { Table } from 'react-bootstrap';
+import { PagingElement } from '../../components/PagingElement';
+import { createEnglishIndex } from '../../functions/createEnglishIndex';
+
+interface SubmissionTableProps {
+  problemNum: number;
+  submissions: any[];
+}
+
+export const SubmissionTable: React.FC<SubmissionTableProps> = ({
+  problemNum,
+  submissions,
+}) => {
+  const [displaySubmissions, setDisplaySubmissions] = useState<any>([]);
+
+  if (submissions.length === 0) {
+    return <div />;
+  }
+
+  const SUBMISSIONS_IN_ONE_PAGE = 5;
+  const pageNum = Math.ceil(submissions.length / SUBMISSIONS_IN_ONE_PAGE);
+  const changeDisplaySubmissions = (page: any) => {
+    const newSubmissions = submissions.filter(
+      (_: any, idx: number) =>
+        page * SUBMISSIONS_IN_ONE_PAGE <= idx &&
+        idx < (page + 1) * SUBMISSIONS_IN_ONE_PAGE
+    );
+    setDisplaySubmissions(newSubmissions);
+  };
+
+  const createTableBody = () => {
+    /**
+     * @param {Object} submit - 提出情報
+     * @param {String} submit.statement - 提出した際の答案
+     * @param {String} submit.result - 提出結果
+     * @param {String} submit.submitTimeAMPM - 提出時間のフォーマット済の文字列
+     */
+    return displaySubmissions.map((submit: any, idx: number) => {
+      return (
+        <tr key={idx}>
+          <td key={idx + 'idx'}>
+            {createEnglishIndex(submit.indexOfContest, problemNum)}
+          </td>
+          <td key={idx + 'stm'}>{submit.statement}</td>
+          <td key={idx + 'res'}>{submit.result}</td>
+          <td key={idx + 'time'}>{submit.submitTimeAMPM}</td>
+        </tr>
+      );
+    });
+  };
+
+  return (
+    <div>
+      <Table striped bordered hover>
+        <thead>
+          <tr>
+            <th>問題</th>
+            <th>提出</th>
+            <th>結果</th>
+            <th>提出時間</th>
+          </tr>
+        </thead>
+        <tbody>{createTableBody()}</tbody>
+      </Table>
+      <PagingElement pageNum={pageNum} pageChanged={changeDisplaySubmissions} />
+    </div>
+  );
+};
+
+SubmissionTable.propTypes = {
+  problemNum: PropTypes.number.isRequired,
+  submissions: PropTypes.array.isRequired,
+};


### PR DESCRIPTION
close  #187
・タブが切り替わるたびに`<input/>`にフォーカスします。
・通信でProblemsを取得するまで、「コンテストが見つかりません」「エラー」と出る問題を修正しました
・軽微なバグを修正
・リファクタリング　＝＞コンポーネント分割（フォルダ構成は暫定策です）

 #133の文脈でコンポーネントの分割を少しやりました。これでもコンポーネントが最大100行程度あるので、もうすこし粒度を細かくしたいですが、このままだと少し難しそうです。