### PR TITLE
[frontend]Change input type of time picker

### DIFF
--- a/frontend/src/components/PagingElement.tsx
+++ b/frontend/src/components/PagingElement.tsx
@@ -15,7 +15,7 @@ export const PagingElement: React.FC<Props> = ({
   currentPage,
   onChange,
   marginPx,
-  savePaging
+  savePaging,
 }) => {
   const pageArr = [...Array(totalPages)].map((_, idx) => idx);
   const params = new URLSearchParams(window.location.search);
@@ -27,7 +27,11 @@ export const PagingElement: React.FC<Props> = ({
     }
     onChange(page);
   };
-  if (savePaging && paramPage !== null && currentPage.toString() !== paramPage) {
+  if (
+    savePaging &&
+    paramPage !== null &&
+    currentPage.toString() !== paramPage
+  ) {
     const newPage = parseInt(paramPage, 10);
     if (!isNaN(newPage)) {
       onChange(newPage);

--- a/frontend/src/functions/HttpRequest.ts
+++ b/frontend/src/functions/HttpRequest.ts
@@ -314,11 +314,10 @@ export function getAccountContestPartHistory(
  * @param indexOfContest
  */
 export function getContestSubmissionsOfRaid(
-    contestId: string,
-    indexOfContest: number
+  contestId: string,
+  indexOfContest: number
 ): Promise<ContestSubmissionOfRaid[]> {
-  return httpRequest(`/api/submissions/${contestId}/raid`, 'GET',
-      {index_of_contest: indexOfContest}) as Promise<
-      ContestSubmissionOfRaid[]
-      >;
+  return httpRequest(`/api/submissions/${contestId}/raid`, 'GET', {
+    index_of_contest: indexOfContest,
+  }) as Promise<ContestSubmissionOfRaid[]>;
 }

--- a/frontend/src/functions/createEnglishIndex.ts
+++ b/frontend/src/functions/createEnglishIndex.ts
@@ -4,9 +4,9 @@ export const createEnglishIndex = (index: number) => {
   let alpha = '';
   index++;
   while (index > 0) {
-      index--;
-      alpha += ALPHABETS[index % ALPHABETS_NUM];
-      index = Math.floor(index / ALPHABETS_NUM);
+    index--;
+    alpha += ALPHABETS[index % ALPHABETS_NUM];
+    index = Math.floor(index / ALPHABETS_NUM);
   }
   return alpha.split('').reverse().join('');
 };

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -198,15 +198,23 @@ const CreateContestElement: VFC = () => {
           <InputGroup className={'mb-3'}>
             <Form.Control
               placeholder={'2021-1-10 21:00:00'}
-              type={'datetime'}
+              type="datetime-local"
               ref={startTimeRef}
+              pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
+              required
             />
           </InputGroup>
         </Col>
         <Col>
           <label>終了日時</label>
           <InputGroup className={'mb-3'}>
-            <Form.Control placeholder={'2021-1-10 21:30:00'} ref={endTimeRef} />
+            <Form.Control
+              placeholder={'2021-1-10 21:30:00'}
+              type="datetime-local"
+              ref={endTimeRef}
+              pattern="[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}"
+              required
+            />
           </InputGroup>
         </Col>
       </Form.Row>

--- a/frontend/src/pages/ContestEditPage.tsx
+++ b/frontend/src/pages/ContestEditPage.tsx
@@ -92,13 +92,13 @@ const EditProblemsElement: FC<EditProblemsElementProps> = ({
     const newProblems = [...problems];
     if (direction === UP_REARRANGE && idx !== 0) {
       const tmp = newProblems[idx];
-      newProblems[idx] = newProblems[idx-1];
-      newProblems[idx-1] = tmp;
+      newProblems[idx] = newProblems[idx - 1];
+      newProblems[idx - 1] = tmp;
     }
     if (direction === DOWN_REARRANGE && idx !== newProblems.length - 1) {
       const tmp = newProblems[idx];
-      newProblems[idx] = newProblems[idx+1];
-      newProblems[idx+1] = tmp;
+      newProblems[idx] = newProblems[idx + 1];
+      newProblems[idx + 1] = tmp;
     }
     setProblems(newProblems);
   };
@@ -169,10 +169,16 @@ const EditProblemsElement: FC<EditProblemsElementProps> = ({
           <button type={'button'} onClick={() => eraseProblem(idx)}>
             -
           </button>
-          <button type={'button'} onClick={() => rearrangeProblem(idx, UP_REARRANGE)}>
+          <button
+            type={'button'}
+            onClick={() => rearrangeProblem(idx, UP_REARRANGE)}
+          >
             ↑
           </button>
-          <button type={'button'} onClick={() => rearrangeProblem(idx, DOWN_REARRANGE)}>
+          <button
+            type={'button'}
+            onClick={() => rearrangeProblem(idx, DOWN_REARRANGE)}
+          >
             ↓
           </button>
         </Col>

--- a/frontend/src/pages/contestPage/ContestStandingsElement.tsx
+++ b/frontend/src/pages/contestPage/ContestStandingsElement.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import Button from 'react-bootstrap/Button';
 import { ContestStandingsTable } from '../../components/ContestStandingsTable';
-import {ContestStandingsTableForRaid} from "../../components/ContestStandingsTableForRaid";
+import { ContestStandingsTableForRaid } from '../../components/ContestStandingsTableForRaid';
 import { useAuthentication } from '../../contexts/AuthenticationContext';
 import { getContestStandingsInfo } from '../../functions/HttpRequest';
 import { findContestIdFromPath } from '../../functions/findContestIdFromPath';
@@ -15,7 +15,7 @@ interface Props {
 export const ContestStandingsElement: React.FC<Props> = ({
   problems,
   standingsVersion,
-  contestType
+  contestType,
 }) => {
   const { accountName } = useAuthentication();
   const [standings, setStandings] = useState<ContestStandingsInfo | null>(null);
@@ -44,25 +44,31 @@ export const ContestStandingsElement: React.FC<Props> = ({
   }
 
   const getStandingsTable = () => {
-      if (contestType === 'RAID') {
-          return standings && (
-              <ContestStandingsTableForRaid
-                  problems={problems}
-                  standings={standings}/>
-          );
-      } else {
-          return standings && (
-              <ContestStandingsTable
-                  myAccountName={accountName}
-                  problems={problems}
-                  standings={standings}/>
-          );
-      }
+    if (contestType === 'RAID') {
+      return (
+        standings && (
+          <ContestStandingsTableForRaid
+            problems={problems}
+            standings={standings}
+          />
+        )
+      );
+    } else {
+      return (
+        standings && (
+          <ContestStandingsTable
+            myAccountName={accountName}
+            problems={problems}
+            standings={standings}
+          />
+        )
+      );
+    }
   };
   return (
     <>
       <p>{myRank}</p>
-        {getStandingsTable()}
+      {getStandingsTable()}
       <Button onClick={getStandings} variant="secondary">
         更新
       </Button>

--- a/frontend/src/pages/contestPage/ProblemsTab.tsx
+++ b/frontend/src/pages/contestPage/ProblemsTab.tsx
@@ -1,106 +1,129 @@
 import { VFC, createRef, useState, useEffect } from 'react';
-import Button from "react-bootstrap/Button";
-import OverlayTrigger from "react-bootstrap/OverlayTrigger";
+import Button from 'react-bootstrap/Button';
+import OverlayTrigger from 'react-bootstrap/OverlayTrigger';
 import Tab from 'react-bootstrap/Tab';
-import Table from 'react-bootstrap/Table'
+import Table from 'react-bootstrap/Table';
 import Tabs from 'react-bootstrap/Tabs';
-import {PagingElement} from "../../components/PagingElement";
-import {getContestSubmissionsOfRaid, postSubmission} from '../../functions/HttpRequest';
+import { PagingElement } from '../../components/PagingElement';
+import {
+  getContestSubmissionsOfRaid,
+  postSubmission,
+} from '../../functions/HttpRequest';
 import { createEnglishIndex } from '../../functions/createEnglishIndex';
 import { findContestIdFromPath } from '../../functions/findContestIdFromPath';
-import {ContestSubmissionOfRaid, ProblemInfo, SubmissionInfo} from '../../types';
+import {
+  ContestSubmissionOfRaid,
+  ProblemInfo,
+  SubmissionInfo,
+} from '../../types';
 import { AnswerSubmitForm } from './AnswerSubmitForm';
 import { ContestStandingsElement } from './ContestStandingsElement';
 import { SubmissionTable } from './SubmissionTable';
 
 interface ProblemTabElementProps {
-    problemInfo: ProblemInfo;
-    contestType: string;
+  problemInfo: ProblemInfo;
+  contestType: string;
 }
-const ProblemTabElement: VFC<ProblemTabElementProps> = ({problemInfo, contestType}) => {
-    const SUBMISSION_IN_ONE_PAGE = 10;
-    const [submissionsOfRaid, setSubmissionsOfRaid] = useState<ContestSubmissionOfRaid[]>([]);
-    const [page, setPage] = useState(0);
-    const getSubmissionTableOfRaid = () => {
-        const tBody: any[] = [];
-        submissionsOfRaid.forEach((submission: ContestSubmissionOfRaid, index: number) => {
-            if (page * SUBMISSION_IN_ONE_PAGE <= index && index < (page + 1) * SUBMISSION_IN_ONE_PAGE) {
-                tBody.push(
-                    <tr key={submission.statement}>
-                        <td>{submission.statement}</td>
-                        <td>{submission.submitCount}</td>
-                        <td>{(submission.accepted)? 'ACCEPTED' : 'WRONG_ANSWER'}</td>
-                    </tr>
-                )
-            }
-        });
-        // デザイン調節用
-        let cnt = 0;
-        while (tBody.length < SUBMISSION_IN_ONE_PAGE) {
-            // : を含む提出は出来ないのでkeyは被らない
-            tBody.push(
-                <tr key={cnt + ':'}>
-                    <td style={{visibility: 'hidden'}}>{'A'}</td>
-                    <td style={{visibility: 'hidden'}}>{'B'}</td>
-                    <td style={{visibility: 'hidden'}}>{'C'}</td>
-                </tr>
-            )
-            cnt++;
+const ProblemTabElement: VFC<ProblemTabElementProps> = ({
+  problemInfo,
+  contestType,
+}) => {
+  const SUBMISSION_IN_ONE_PAGE = 10;
+  const [submissionsOfRaid, setSubmissionsOfRaid] = useState<
+    ContestSubmissionOfRaid[]
+  >([]);
+  const [page, setPage] = useState(0);
+  const getSubmissionTableOfRaid = () => {
+    const tBody: any[] = [];
+    submissionsOfRaid.forEach(
+      (submission: ContestSubmissionOfRaid, index: number) => {
+        if (
+          page * SUBMISSION_IN_ONE_PAGE <= index &&
+          index < (page + 1) * SUBMISSION_IN_ONE_PAGE
+        ) {
+          tBody.push(
+            <tr key={submission.statement}>
+              <td>{submission.statement}</td>
+              <td>{submission.submitCount}</td>
+              <td>{submission.accepted ? 'ACCEPTED' : 'WRONG_ANSWER'}</td>
+            </tr>
+          );
         }
-        return <div style={{background: '#ccccff', zIndex: 4}}>
-            <Table striped bordered hover>
-                <thead>
-                <tr>
-                    <th>解答</th>
-                    <th>提出回数</th>
-                    <th>結果</th>
-                </tr>
-                </thead>
-                <tbody>
-                {tBody}
-                </tbody>
-            </Table>
-            <PagingElement
-                totalPages={Math.ceil(submissionsOfRaid.length / SUBMISSION_IN_ONE_PAGE)}
-                currentPage={page}
-                onChange={setPage}
-                savePaging={false}
-                marginPx={10}/>
-        </div>
-    };
-    const setSubmissions = async () => {
-      const submissions = await getContestSubmissionsOfRaid(findContestIdFromPath(), problemInfo.indexOfContest);
-      setSubmissionsOfRaid(submissions);
-    };
-    const getOverLayForRaid = () => {
-      return <OverlayTrigger
-          rootClose={true}
-          trigger={'click'}
-          delay={0}
-          defaultShow={false}
-          onToggle={setSubmissions}
-          flip={true}
-          overlay={getSubmissionTableOfRaid()}
-          placement={'right-start'}>
-          <Button variant={'primary'}>みんなの解答を見る</Button>
+      }
+    );
+    // デザイン調節用
+    let cnt = 0;
+    while (tBody.length < SUBMISSION_IN_ONE_PAGE) {
+      // : を含む提出は出来ないのでkeyは被らない
+      tBody.push(
+        <tr key={cnt + ':'}>
+          <td style={{ visibility: 'hidden' }}>{'A'}</td>
+          <td style={{ visibility: 'hidden' }}>{'B'}</td>
+          <td style={{ visibility: 'hidden' }}>{'C'}</td>
+        </tr>
+      );
+      cnt++;
+    }
+    return (
+      <div style={{ background: '#ccccff', zIndex: 4 }}>
+        <Table striped bordered hover>
+          <thead>
+            <tr>
+              <th>解答</th>
+              <th>提出回数</th>
+              <th>結果</th>
+            </tr>
+          </thead>
+          <tbody>{tBody}</tbody>
+        </Table>
+        <PagingElement
+          totalPages={Math.ceil(
+            submissionsOfRaid.length / SUBMISSION_IN_ONE_PAGE
+          )}
+          currentPage={page}
+          onChange={setPage}
+          savePaging={false}
+          marginPx={10}
+        />
+      </div>
+    );
+  };
+  const setSubmissions = async () => {
+    const submissions = await getContestSubmissionsOfRaid(
+      findContestIdFromPath(),
+      problemInfo.indexOfContest
+    );
+    setSubmissionsOfRaid(submissions);
+  };
+  const getOverLayForRaid = () => {
+    return (
+      <OverlayTrigger
+        rootClose={true}
+        trigger={'click'}
+        delay={0}
+        defaultShow={false}
+        onToggle={setSubmissions}
+        flip={true}
+        overlay={getSubmissionTableOfRaid()}
+        placement={'right-start'}
+      >
+        <Button variant={'primary'}>みんなの解答を見る</Button>
       </OverlayTrigger>
-    };
-    return <>
+    );
+  };
+  return (
+    <>
       <h6>{'point: ' + problemInfo.point}</h6>
       {problemInfo.quiz ? (
-          <h4 style={{ color: 'red' }}>
-            ※この問題は最初の提出のみ有効です！！
-          </h4>
+        <h4 style={{ color: 'red' }}>※この問題は最初の提出のみ有効です！！</h4>
       ) : null}
-      {contestType === 'RAID' ? (
-          getOverLayForRaid()
-      ): null}
+      {contestType === 'RAID' ? getOverLayForRaid() : null}
       <div className={'div-pre'}>
         <p>{problemInfo.statement}</p>
       </div>
-    </>;
+    </>
+  );
 };
-
 
 interface ProblemsTabProps {
   contestName: string;
@@ -110,7 +133,11 @@ interface ProblemsTabProps {
 }
 
 const KEY_OF_MY_SUBMISSIONS = 'mySubmit';
-export const ProblemsTab: VFC<ProblemsTabProps> = ({ problems, submissions,contestType}) => {
+export const ProblemsTab: VFC<ProblemsTabProps> = ({
+  problems,
+  submissions,
+  contestType,
+}) => {
   const answerInput = createRef<HTMLInputElement>();
   const [comment, setComment] = useState('');
   const [key, setKey] = useState(KEY_OF_MY_SUBMISSIONS);
@@ -165,7 +192,7 @@ export const ProblemsTab: VFC<ProblemsTabProps> = ({ problems, submissions,conte
           key={problem.indexOfContest}
           title={problemTitle}
         >
-          <ProblemTabElement problemInfo={problem} contestType={contestType}/>
+          <ProblemTabElement problemInfo={problem} contestType={contestType} />
         </Tab>
       );
     });
@@ -246,9 +273,7 @@ export const ProblemsTab: VFC<ProblemsTabProps> = ({ problems, submissions,conte
           submitAnswer={submitAnswer}
         />
       ) : (
-        <SubmissionTable
-          submissions={nowSubmissions}
-        />
+        <SubmissionTable submissions={nowSubmissions} />
       )}
 
       <p>{comment}</p>

--- a/frontend/src/pages/contestPage/SubmissionTable.tsx
+++ b/frontend/src/pages/contestPage/SubmissionTable.tsx
@@ -9,9 +9,7 @@ interface Props {
   submissions: SubmissionInfo[];
 }
 
-export const SubmissionTable: React.FC<Props> = ({
-  submissions,
-}) => {
+export const SubmissionTable: React.FC<Props> = ({ submissions }) => {
   const [page, setPage] = useState(0);
 
   const SUBMISSIONS_IN_ONE_PAGE = 5;
@@ -47,9 +45,7 @@ export const SubmissionTable: React.FC<Props> = ({
     return pagedContent[page].map((submit, idx: number) => {
       return (
         <tr key={idx}>
-          <td key={idx + 'idx'}>
-            {createEnglishIndex(submit.indexOfContest)}
-          </td>
+          <td key={idx + 'idx'}>{createEnglishIndex(submit.indexOfContest)}</td>
           <td key={idx + 'stm'}>{submit.statement}</td>
           <td key={idx + 'res'}>{submit.result}</td>
           <td key={idx + 'time'}>{submit.submitTimeAMPM}</td>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -181,7 +181,7 @@ export interface AccountContestPartHistory {
 }
 
 export interface ContestSubmissionOfRaid {
-    statement: string;
-    submitCount: number;
-    accepted: boolean;
+  statement: string;
+  submitCount: number;
+  accepted: boolean;
 }


### PR DESCRIPTION
close #203 

このプルリクエストはコンテスト作成の時間指定について、inputのtypeを`datetime`から`datetime-local`に変更します。これにより時間をカレンダーから入力できるようになり、形式に沿わない入力ができないようになります。

pattern属性で数値以外が入力できないように設定しています。
この実装は[MDNの実装](https://developer.mozilla.org/ja/docs/Web/HTML/Element/input/datetime-local#handling_browser_support)を参考にしました。 


最初のコミットはフォーマット、つぎのコミットはprettierのフォーマットです。コミットごとに見たほうがわかりやすいと思います。