### PR TITLE
ツイートボタン設置

### DIFF
--- a/frontend/src/pages/ContestPage/ContestStandingsTable.tsx
+++ b/frontend/src/pages/ContestPage/ContestStandingsTable.tsx
@@ -300,7 +300,6 @@ const StandingsTable: VFC<StandingsTableProps> = ({
     () => problems.sort((a, b) => a.indexOfContest - b.indexOfContest),
     [problems]
   );
-  console.log('stand', paginatedAccounts);
   const firstAcceptRow = useMemo(
     () => (
       <tr className="small text-center text-nowrap">

--- a/frontend/src/pages/ContestPage/index.tsx
+++ b/frontend/src/pages/ContestPage/index.tsx
@@ -212,7 +212,6 @@ const useContestPage = () => {
 
     fetchData();
   }, []);
-  console.log(writers);
   const tweetContent = [
     '【コンテスト開催のお知らせ】',
     contestName,

--- a/frontend/src/pages/ContestPage/index.tsx
+++ b/frontend/src/pages/ContestPage/index.tsx
@@ -103,6 +103,7 @@ const useContestPage = () => {
   });
   const [writers, setWriters] = useState<string[]>([]);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [ratedBound, setRatedBound] = useState(0);
 
   const ratingUpdate = () => {
     updateContestRating(findContestIdFromPath())
@@ -169,7 +170,6 @@ const useContestPage = () => {
 
       const [contestInfo, problems, submissions, accountInfo] = resources;
 
-      console.log(contestInfo);
       setContestName(contestInfo.name);
       setStatement(contestInfo.statement);
       setContestType(contestInfo.contestType);
@@ -179,6 +179,7 @@ const useContestPage = () => {
       setWriters(
         contestInfo.contestCreators.map((creator) => creator.accountName)
       );
+      setRatedBound(contestInfo.ratedBound);
 
       if (accountInfo) {
         const youCanUpdateRating = (
@@ -217,7 +218,10 @@ const useContestPage = () => {
     contestName,
     `writer: ${writers.join(', ')}\n`,
     time,
-    'このコンテストによるレートの変動はありません。',
+    '',
+    ratedBound > 0
+      ? `0 ~ ${ratedBound}までがrated対象になります。`
+      : 'このコンテストによるレートの変動はありません。',
   ].join('\n');
   const tweetUrl = encodeURI(
     `https://twitter.com/share?ref_src=twsrc%5Etfw&text=${tweetContent}&hashtags=Shitforces,くそなぞなぞ&url=${window.location.href}`

--- a/frontend/src/pages/ContestPage/index.tsx
+++ b/frontend/src/pages/ContestPage/index.tsx
@@ -33,6 +33,8 @@ const ContestPage: FC = () => {
     problems,
     submissions,
     contestType,
+    tweetUrl,
+    isAdmin,
   } = useContestPage();
 
   return (
@@ -63,11 +65,30 @@ const ContestPage: FC = () => {
           contestType={contestType}
         />
       )}
+      {isAdmin && (
+        <div>
+          <a
+            href={tweetUrl}
+            className="twitter-share-button"
+            data-show-count="false"
+            target="_blank"
+            rel="noreferrer"
+          >
+            コンテストの通知をツイート
+          </a>
+          <script
+            async
+            src="https://platform.twitter.com/widgets.js"
+            charSet="utf-8"
+          ></script>
+        </div>
+      )}
     </div>
   );
 };
 
 const useContestPage = () => {
+  // TODO useStateの数減らしたくない？
   const [contestName, setContestName] = useState('');
   const [statement, setStatement] = useState('');
   const [contestType, setContestType] = useState<ContestType | null>(null);
@@ -80,6 +101,9 @@ const useContestPage = () => {
   const [contestEditButtonStyle, setContestEditButtonStyle] = useState({
     display: 'none',
   });
+  const [writers, setWriters] = useState<string[]>([]);
+  const [isAdmin, setIsAdmin] = useState(false);
+
   const ratingUpdate = () => {
     updateContestRating(findContestIdFromPath())
       .then(() => {
@@ -145,12 +169,16 @@ const useContestPage = () => {
 
       const [contestInfo, problems, submissions, accountInfo] = resources;
 
+      console.log(contestInfo);
       setContestName(contestInfo.name);
       setStatement(contestInfo.statement);
       setContestType(contestInfo.contestType);
       setTime(`${contestInfo.startTimeAMPM} ~ ${contestInfo.endTimeAMPM}`);
       setProblems(problems);
       setSubmissions(submissions);
+      setWriters(
+        contestInfo.contestCreators.map((creator) => creator.accountName)
+      );
 
       if (accountInfo) {
         const youCanUpdateRating = (
@@ -177,11 +205,23 @@ const useContestPage = () => {
         ) {
           setContestEditButtonStyle({ display: 'block' });
         }
+        setIsAdmin(accountInfo.auth == ADMINISTRATOR);
       }
     };
 
     fetchData();
   }, []);
+  console.log(writers);
+  const tweetContent = [
+    '【コンテスト開催のお知らせ】',
+    contestName,
+    `writer: ${writers.join(', ')}\n`,
+    time,
+    'このコンテストによるレートの変動はありません。',
+  ].join('\n');
+  const tweetUrl = encodeURI(
+    `https://twitter.com/share?ref_src=twsrc%5Etfw&text=${tweetContent}&hashtags=Shitforces,くそなぞなぞ&url=${window.location.href}`
+  );
 
   return {
     ratingUpdate,
@@ -193,6 +233,8 @@ const useContestPage = () => {
     problems,
     submissions,
     contestType,
+    tweetUrl,
+    isAdmin,
   };
 };
 


### PR DESCRIPTION

https://github.com/ShopOne/Shitforces/issues/241 の通知をツイートボタンを設置する感じの実装にしました
ツイートの内容
![スクリーンショット 2021-12-04 22-46-43](https://user-images.githubusercontent.com/8833998/144711837-e95b8590-5093-4f98-9ab4-6eb542fc08ed.png)
ツイートボタンの位置は一番下です
![スクリーンショット 2021-12-04 22-47-02](https://user-images.githubusercontent.com/8833998/144711854-41d4a088-e842-45f8-8669-12d3d504afa6.png)
